### PR TITLE
Test development branches of Coq.

### DIFF
--- a/.github/workflows/nix-action-master.yml
+++ b/.github/workflows/nix-action-master.yml
@@ -1,0 +1,169 @@
+jobs:
+  coq:
+    needs: []
+    runs-on: ubuntu-latest
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup coq-community
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: coq-community
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target coq
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
+        \ bundle \"master\" --argstr job \"coq\" \\\n --dry-run 2>&1 > /dev/null)\n\
+        echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
+        \ \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "master"
+        --argstr job "coq"
+  coq-shell:
+    needs:
+    - coq
+    runs-on: ubuntu-latest
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup coq-community
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: coq-community
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target coq-shell
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
+        \ bundle \"master\" --argstr job \"coq-shell\" \\\n --dry-run 2>&1 > /dev/null)\n\
+        echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
+        \ \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "master"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "master"
+        --argstr job "coq-shell"
+  heq:
+    needs:
+    - coq
+    - coq
+    runs-on: ubuntu-latest
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup coq-community
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: coq-community
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target heq
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
+        \ bundle \"master\" --argstr job \"heq\" \\\n --dry-run 2>&1 > /dev/null)\n\
+        echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
+        \ \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "master"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "master"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "master"
+        --argstr job "heq"
+  mathcomp-bigenough:
+    needs:
+    - coq
+    runs-on: ubuntu-latest
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup coq-community
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: coq-community
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target mathcomp-bigenough
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
+        \ bundle \"master\" --argstr job \"mathcomp-bigenough\" \\\n --dry-run 2>&1\
+        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "master"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "master"
+        --argstr job "mathcomp-bigenough"
+name: Nix CI for bundle master
+'on':
+  pull_request:
+    branches:
+    - '**'
+  push:
+    branches:
+    - master

--- a/.github/workflows/nix-action-v8.14.yml
+++ b/.github/workflows/nix-action-v8.14.yml
@@ -1,0 +1,169 @@
+jobs:
+  coq:
+    needs: []
+    runs-on: ubuntu-latest
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup coq-community
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: coq-community
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target coq
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
+        \ bundle \"v8.14\" --argstr job \"coq\" \\\n --dry-run 2>&1 > /dev/null)\n\
+        echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
+        \ \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "v8.14"
+        --argstr job "coq"
+  coq-shell:
+    needs:
+    - coq
+    runs-on: ubuntu-latest
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup coq-community
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: coq-community
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target coq-shell
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
+        \ bundle \"v8.14\" --argstr job \"coq-shell\" \\\n --dry-run 2>&1 > /dev/null)\n\
+        echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
+        \ \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "v8.14"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "v8.14"
+        --argstr job "coq-shell"
+  heq:
+    needs:
+    - coq
+    - coq
+    runs-on: ubuntu-latest
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup coq-community
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: coq-community
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target heq
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
+        \ bundle \"v8.14\" --argstr job \"heq\" \\\n --dry-run 2>&1 > /dev/null)\n\
+        echo ::set-output name=status::$(echo $nb_dry_run | grep \"built:\" | sed\
+        \ \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "v8.14"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "v8.14"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "v8.14"
+        --argstr job "heq"
+  mathcomp-bigenough:
+    needs:
+    - coq
+    runs-on: ubuntu-latest
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Cachix install
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq
+      uses: cachix/cachix-action@v8
+      with:
+        name: coq
+    - name: Cachix setup coq-community
+      uses: cachix/cachix-action@v8
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: coq-community
+    - name: Cachix setup math-comp
+      uses: cachix/cachix-action@v8
+      with:
+        name: math-comp
+    - id: stepCheck
+      name: Checking presence of CI target mathcomp-bigenough
+      run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n --argstr\
+        \ bundle \"v8.14\" --argstr job \"mathcomp-bigenough\" \\\n --dry-run 2>&1\
+        \ > /dev/null)\necho ::set-output name=status::$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\")\n"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: coq'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "v8.14"
+        --argstr job "coq"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "v8.14"
+        --argstr job "mathcomp-bigenough"
+name: Nix CI for bundle v8.14
+'on':
+  pull_request:
+    branches:
+    - '**'
+  push:
+    branches:
+    - master

--- a/.nix/fallback-config.nix
+++ b/.nix/fallback-config.nix
@@ -18,9 +18,12 @@ with (import <nixpkgs> {}).lib;
   ## write one `bundles.name` attribute set per
   ## alternative configuration, the can be used to
   ## compute several ci jobs as well
-  bundles = genAttrs [ "8.10" "8.11" "8.12" "8.13" ]
+  bundles = genAttrs [ "8.10" "8.11" "8.12" "8.13" "v8.14" "master" ]
     (v: {
       coqPackages.coq.override.version = v;
+      coqPackages.coq-shell.job = false;
+      coqPackages.heq.job = false;
+      coqPackages.mathcomp-bigenough.job = false;
     });
 
   cachix.coq = {};

--- a/.nix/nixpkgs.nix
+++ b/.nix/nixpkgs.nix
@@ -1,4 +1,4 @@
 fetchTarball {
-    url = https://github.com/NixOS/nixpkgs/archive/4ff1a6f91a003c50247990dfa2a335304ca0aabb.tar.gz;
-    sha256 = "1x44mx6c0g54njp6nx4sa170njjbhk3vsw4v16b5dgvf42axw7zq";
+    url = https://github.com/NixOS/nixpkgs/archive/cc84f3906e1386fd4008e78130566c96776ba44e.tar.gz;
+    sha256 = "14dw9cawklr76v8m2658aqllfasmblhycq8z0fsy1ink02g6rdpn";
   }


### PR DESCRIPTION
I am facing a new issue: `coqPackages.<package>.job = false` seems like a no-op. I can't get rid of the `coq-shell`, `heq` and `mathcomp-bigenough` reverse dependencies of Coq in the generated workflow.