### PR TITLE
Fix assignment after removal of ::set-output

### DIFF
--- a/.github/workflows/nix-action-8.10.yml
+++ b/.github/workflows/nix-action-8.10.yml
@@ -42,8 +42,8 @@ jobs:
       name: Checking presence of CI target Cheerios
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"Cheerios\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -99,8 +99,8 @@ jobs:
       name: Checking presence of CI target CoLoR
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"CoLoR\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -157,8 +157,8 @@ jobs:
       name: Checking presence of CI target ITree
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"ITree\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -217,8 +217,8 @@ jobs:
       name: Checking presence of CI target InfSeqExt
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"InfSeqExt\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -272,8 +272,8 @@ jobs:
       name: Checking presence of CI target QuickChick
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"QuickChick\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -336,8 +336,8 @@ jobs:
       name: Checking presence of CI target StructTact
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"StructTact\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -391,8 +391,8 @@ jobs:
       name: Checking presence of CI target Verdi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"Verdi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -455,8 +455,8 @@ jobs:
       name: Checking presence of CI target aac-tactics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"aac-tactics\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -508,8 +508,8 @@ jobs:
       name: Checking presence of CI target autosubst
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"autosubst\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -564,8 +564,8 @@ jobs:
       name: Checking presence of CI target bignums
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"bignums\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -618,8 +618,8 @@ jobs:
       name: Checking presence of CI target category-theory
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"category-theory\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -678,8 +678,8 @@ jobs:
       name: Checking presence of CI target ceres
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"ceres\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -731,8 +731,8 @@ jobs:
       name: Checking presence of CI target compcert
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"compcert\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -786,8 +786,8 @@ jobs:
       name: Checking presence of CI target coq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"coq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: Building/fetching current CI target
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -835,8 +835,8 @@ jobs:
       name: Checking presence of CI target coq-bits
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"coq-bits\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -891,8 +891,8 @@ jobs:
       name: Checking presence of CI target coq-ext-lib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"coq-ext-lib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -943,8 +943,8 @@ jobs:
       name: Checking presence of CI target coq-record-update
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"coq-record-update\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -995,8 +995,8 @@ jobs:
       name: Checking presence of CI target coq-shell
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"coq-shell\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -1052,8 +1052,8 @@ jobs:
       name: Checking presence of CI target coqeal
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"coqeal\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -1124,8 +1124,8 @@ jobs:
       name: Checking presence of CI target coqhammer
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"coqhammer\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -1177,8 +1177,8 @@ jobs:
       name: Checking presence of CI target coqprime
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"coqprime\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -1234,8 +1234,8 @@ jobs:
       name: Checking presence of CI target coquelicot
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"coquelicot\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -1292,8 +1292,8 @@ jobs:
       name: Checking presence of CI target corn
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"corn\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -1352,8 +1352,8 @@ jobs:
       name: Checking presence of CI target dpdgraph
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"dpdgraph\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -1404,8 +1404,8 @@ jobs:
       name: Checking presence of CI target equations
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"equations\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -1457,8 +1457,8 @@ jobs:
       name: Checking presence of CI target extructures
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"extructures\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -1513,8 +1513,8 @@ jobs:
       name: Checking presence of CI target flocq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"flocq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -1568,8 +1568,8 @@ jobs:
       name: Checking presence of CI target fourcolor
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"fourcolor\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -1635,8 +1635,8 @@ jobs:
       name: Checking presence of CI target gaia
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"gaia\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -1700,8 +1700,8 @@ jobs:
       name: Checking presence of CI target gappalib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"gappalib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -1761,8 +1761,8 @@ jobs:
       name: Checking presence of CI target interval
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"interval\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -1834,8 +1834,8 @@ jobs:
       name: Checking presence of CI target iris
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"iris\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -1890,8 +1890,8 @@ jobs:
       name: Checking presence of CI target ltac2
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"ltac2\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -1943,8 +1943,8 @@ jobs:
       name: Checking presence of CI target math-classes
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"math-classes\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -2005,8 +2005,8 @@ jobs:
       name: Checking presence of CI target mathcomp
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"mathcomp\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -2083,8 +2083,8 @@ jobs:
       name: Checking presence of CI target mathcomp-abel
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"mathcomp-abel\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -2145,8 +2145,8 @@ jobs:
       name: Checking presence of CI target mathcomp-algebra
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"mathcomp-algebra\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -2206,8 +2206,8 @@ jobs:
       name: Checking presence of CI target mathcomp-bigenough
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"mathcomp-bigenough\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -2267,8 +2267,8 @@ jobs:
       name: Checking presence of CI target mathcomp-character
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"mathcomp-character\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -2343,8 +2343,8 @@ jobs:
       name: Checking presence of CI target mathcomp-field
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"mathcomp-field\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -2412,8 +2412,8 @@ jobs:
       name: Checking presence of CI target mathcomp-fingroup
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"mathcomp-fingroup\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -2469,8 +2469,8 @@ jobs:
       name: Checking presence of CI target mathcomp-finmap
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"mathcomp-finmap\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -2531,8 +2531,8 @@ jobs:
       name: Checking presence of CI target mathcomp-real-closed
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"mathcomp-real-closed\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -2610,8 +2610,8 @@ jobs:
       name: Checking presence of CI target mathcomp-solvable
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"mathcomp-solvable\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -2674,8 +2674,8 @@ jobs:
       name: Checking presence of CI target mathcomp-ssreflect
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"mathcomp-ssreflect\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -2728,8 +2728,8 @@ jobs:
       name: Checking presence of CI target mathcomp-tarjan
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"mathcomp-tarjan\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -2788,8 +2788,8 @@ jobs:
       name: Checking presence of CI target metalib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"metalib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -2845,8 +2845,8 @@ jobs:
       name: Checking presence of CI target multinomials
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"multinomials\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -2924,8 +2924,8 @@ jobs:
       name: Checking presence of CI target odd-order
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"odd-order\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -3004,8 +3004,8 @@ jobs:
       name: Checking presence of CI target paco
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"paco\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -3056,8 +3056,8 @@ jobs:
       name: Checking presence of CI target paramcoq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"paramcoq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -3108,8 +3108,8 @@ jobs:
       name: Checking presence of CI target pocklington
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"pocklington\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -3161,8 +3161,8 @@ jobs:
       name: Checking presence of CI target reglang
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"reglang\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -3219,8 +3219,8 @@ jobs:
       name: Checking presence of CI target relation-algebra
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"relation-algebra\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -3279,8 +3279,8 @@ jobs:
       name: Checking presence of CI target semantics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"semantics\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -3331,8 +3331,8 @@ jobs:
       name: Checking presence of CI target serapi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"serapi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -3384,8 +3384,8 @@ jobs:
       name: Checking presence of CI target simple-io
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"simple-io\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -3440,8 +3440,8 @@ jobs:
       name: Checking presence of CI target smpl
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"smpl\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -3492,8 +3492,8 @@ jobs:
       name: Checking presence of CI target stdpp
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"stdpp\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -3544,8 +3544,8 @@ jobs:
       name: Checking presence of CI target tlc
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"tlc\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -3597,8 +3597,8 @@ jobs:
       name: Checking presence of CI target topology
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"topology\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr
@@ -3653,8 +3653,8 @@ jobs:
       name: Checking presence of CI target zorns-lemma
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.10\" --argstr job \"zorns-lemma\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.10" --argstr

--- a/.github/workflows/nix-action-8.11.yml
+++ b/.github/workflows/nix-action-8.11.yml
@@ -42,8 +42,8 @@ jobs:
       name: Checking presence of CI target Cheerios
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"Cheerios\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -99,8 +99,8 @@ jobs:
       name: Checking presence of CI target CoLoR
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"CoLoR\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -157,8 +157,8 @@ jobs:
       name: Checking presence of CI target ITree
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"ITree\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -217,8 +217,8 @@ jobs:
       name: Checking presence of CI target InfSeqExt
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"InfSeqExt\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -269,8 +269,8 @@ jobs:
       name: Checking presence of CI target LibHyps
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"LibHyps\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -324,8 +324,8 @@ jobs:
       name: Checking presence of CI target QuickChick
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"QuickChick\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -388,8 +388,8 @@ jobs:
       name: Checking presence of CI target StructTact
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"StructTact\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -443,8 +443,8 @@ jobs:
       name: Checking presence of CI target Verdi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"Verdi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -507,8 +507,8 @@ jobs:
       name: Checking presence of CI target aac-tactics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"aac-tactics\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -563,8 +563,8 @@ jobs:
       name: Checking presence of CI target addition-chains
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"addition-chains\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -632,8 +632,8 @@ jobs:
       name: Checking presence of CI target autosubst
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"autosubst\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -688,8 +688,8 @@ jobs:
       name: Checking presence of CI target bignums
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"bignums\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -742,8 +742,8 @@ jobs:
       name: Checking presence of CI target category-theory
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"category-theory\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -802,8 +802,8 @@ jobs:
       name: Checking presence of CI target ceres
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"ceres\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -855,8 +855,8 @@ jobs:
       name: Checking presence of CI target compcert
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"compcert\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -910,8 +910,8 @@ jobs:
       name: Checking presence of CI target coq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"coq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: Building/fetching current CI target
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -959,8 +959,8 @@ jobs:
       name: Checking presence of CI target coq-bits
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"coq-bits\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -1015,8 +1015,8 @@ jobs:
       name: Checking presence of CI target coq-elpi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"coq-elpi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -1067,8 +1067,8 @@ jobs:
       name: Checking presence of CI target coq-ext-lib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"coq-ext-lib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -1119,8 +1119,8 @@ jobs:
       name: Checking presence of CI target coq-record-update
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"coq-record-update\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -1171,8 +1171,8 @@ jobs:
       name: Checking presence of CI target coq-shell
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"coq-shell\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -1228,8 +1228,8 @@ jobs:
       name: Checking presence of CI target coqeal
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"coqeal\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -1300,8 +1300,8 @@ jobs:
       name: Checking presence of CI target coqhammer
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"coqhammer\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -1353,8 +1353,8 @@ jobs:
       name: Checking presence of CI target coqprime
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"coqprime\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -1409,8 +1409,8 @@ jobs:
       name: Checking presence of CI target coqtail-math
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"coqtail-math\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -1462,8 +1462,8 @@ jobs:
       name: Checking presence of CI target coquelicot
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"coquelicot\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -1520,8 +1520,8 @@ jobs:
       name: Checking presence of CI target corn
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"corn\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -1581,8 +1581,8 @@ jobs:
       name: Checking presence of CI target deriving
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"deriving\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -1637,8 +1637,8 @@ jobs:
       name: Checking presence of CI target dpdgraph
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"dpdgraph\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -1689,8 +1689,8 @@ jobs:
       name: Checking presence of CI target equations
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"equations\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -1743,8 +1743,8 @@ jobs:
       name: Checking presence of CI target extructures
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"extructures\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -1803,8 +1803,8 @@ jobs:
       name: Checking presence of CI target flocq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"flocq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -1858,8 +1858,8 @@ jobs:
       name: Checking presence of CI target fourcolor
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"fourcolor\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -1925,8 +1925,8 @@ jobs:
       name: Checking presence of CI target gaia
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"gaia\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -1990,8 +1990,8 @@ jobs:
       name: Checking presence of CI target gappalib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"gappalib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -2048,8 +2048,8 @@ jobs:
       name: Checking presence of CI target goedel
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"goedel\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -2109,8 +2109,8 @@ jobs:
       name: Checking presence of CI target hierarchy-builder
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"hierarchy-builder\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -2166,8 +2166,8 @@ jobs:
       name: Checking presence of CI target hydra-battles
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"hydra-battles\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -2227,8 +2227,8 @@ jobs:
       name: Checking presence of CI target interval
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"interval\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -2300,8 +2300,8 @@ jobs:
       name: Checking presence of CI target iris
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"iris\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -2357,8 +2357,8 @@ jobs:
       name: Checking presence of CI target math-classes
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"math-classes\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -2419,8 +2419,8 @@ jobs:
       name: Checking presence of CI target mathcomp
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"mathcomp\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -2497,8 +2497,8 @@ jobs:
       name: Checking presence of CI target mathcomp-abel
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"mathcomp-abel\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -2559,8 +2559,8 @@ jobs:
       name: Checking presence of CI target mathcomp-algebra
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"mathcomp-algebra\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -2620,8 +2620,8 @@ jobs:
       name: Checking presence of CI target mathcomp-bigenough
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"mathcomp-bigenough\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -2681,8 +2681,8 @@ jobs:
       name: Checking presence of CI target mathcomp-character
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"mathcomp-character\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -2757,8 +2757,8 @@ jobs:
       name: Checking presence of CI target mathcomp-field
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"mathcomp-field\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -2826,8 +2826,8 @@ jobs:
       name: Checking presence of CI target mathcomp-fingroup
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"mathcomp-fingroup\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -2883,8 +2883,8 @@ jobs:
       name: Checking presence of CI target mathcomp-finmap
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"mathcomp-finmap\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -2945,8 +2945,8 @@ jobs:
       name: Checking presence of CI target mathcomp-real-closed
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"mathcomp-real-closed\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -3024,8 +3024,8 @@ jobs:
       name: Checking presence of CI target mathcomp-solvable
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"mathcomp-solvable\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -3088,8 +3088,8 @@ jobs:
       name: Checking presence of CI target mathcomp-ssreflect
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"mathcomp-ssreflect\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -3142,8 +3142,8 @@ jobs:
       name: Checking presence of CI target mathcomp-tarjan
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"mathcomp-tarjan\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -3207,8 +3207,8 @@ jobs:
       name: Checking presence of CI target metacoq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"metacoq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -3283,8 +3283,8 @@ jobs:
       name: Checking presence of CI target metacoq-erasure
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"metacoq-erasure\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -3353,8 +3353,8 @@ jobs:
       name: Checking presence of CI target metacoq-pcuic
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"metacoq-pcuic\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -3416,8 +3416,8 @@ jobs:
       name: Checking presence of CI target metacoq-safechecker
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"metacoq-safechecker\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -3481,8 +3481,8 @@ jobs:
       name: Checking presence of CI target metacoq-template-coq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"metacoq-template-coq\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -3537,8 +3537,8 @@ jobs:
       name: Checking presence of CI target metalib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"metalib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -3594,8 +3594,8 @@ jobs:
       name: Checking presence of CI target multinomials
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"multinomials\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -3673,8 +3673,8 @@ jobs:
       name: Checking presence of CI target odd-order
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"odd-order\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -3753,8 +3753,8 @@ jobs:
       name: Checking presence of CI target paco
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"paco\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -3805,8 +3805,8 @@ jobs:
       name: Checking presence of CI target paramcoq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"paramcoq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -3857,8 +3857,8 @@ jobs:
       name: Checking presence of CI target pocklington
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"pocklington\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -3910,8 +3910,8 @@ jobs:
       name: Checking presence of CI target reglang
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"reglang\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -3968,8 +3968,8 @@ jobs:
       name: Checking presence of CI target relation-algebra
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"relation-algebra\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -4028,8 +4028,8 @@ jobs:
       name: Checking presence of CI target semantics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"semantics\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -4080,8 +4080,8 @@ jobs:
       name: Checking presence of CI target serapi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"serapi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -4133,8 +4133,8 @@ jobs:
       name: Checking presence of CI target simple-io
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"simple-io\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -4189,8 +4189,8 @@ jobs:
       name: Checking presence of CI target stdpp
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"stdpp\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -4241,8 +4241,8 @@ jobs:
       name: Checking presence of CI target tlc
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"tlc\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -4294,8 +4294,8 @@ jobs:
       name: Checking presence of CI target topology
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"topology\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr
@@ -4350,8 +4350,8 @@ jobs:
       name: Checking presence of CI target zorns-lemma
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.11\" --argstr job \"zorns-lemma\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.11" --argstr

--- a/.github/workflows/nix-action-8.12.yml
+++ b/.github/workflows/nix-action-8.12.yml
@@ -42,8 +42,8 @@ jobs:
       name: Checking presence of CI target Cheerios
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"Cheerios\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -99,8 +99,8 @@ jobs:
       name: Checking presence of CI target CoLoR
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"CoLoR\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -157,8 +157,8 @@ jobs:
       name: Checking presence of CI target ITree
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"ITree\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -217,8 +217,8 @@ jobs:
       name: Checking presence of CI target InfSeqExt
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"InfSeqExt\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -269,8 +269,8 @@ jobs:
       name: Checking presence of CI target LibHyps
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"LibHyps\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -324,8 +324,8 @@ jobs:
       name: Checking presence of CI target QuickChick
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"QuickChick\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -388,8 +388,8 @@ jobs:
       name: Checking presence of CI target StructTact
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"StructTact\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -442,8 +442,8 @@ jobs:
       name: Checking presence of CI target VST
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"VST\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -505,8 +505,8 @@ jobs:
       name: Checking presence of CI target Verdi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"Verdi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -569,8 +569,8 @@ jobs:
       name: Checking presence of CI target aac-tactics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"aac-tactics\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -625,8 +625,8 @@ jobs:
       name: Checking presence of CI target addition-chains
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"addition-chains\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -694,8 +694,8 @@ jobs:
       name: Checking presence of CI target autosubst
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"autosubst\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -750,8 +750,8 @@ jobs:
       name: Checking presence of CI target bignums
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"bignums\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -804,8 +804,8 @@ jobs:
       name: Checking presence of CI target category-theory
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"category-theory\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -864,8 +864,8 @@ jobs:
       name: Checking presence of CI target ceres
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"ceres\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -917,8 +917,8 @@ jobs:
       name: Checking presence of CI target compcert
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"compcert\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -972,8 +972,8 @@ jobs:
       name: Checking presence of CI target coq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"coq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: Building/fetching current CI target
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -1021,8 +1021,8 @@ jobs:
       name: Checking presence of CI target coq-bits
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"coq-bits\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -1077,8 +1077,8 @@ jobs:
       name: Checking presence of CI target coq-elpi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"coq-elpi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -1129,8 +1129,8 @@ jobs:
       name: Checking presence of CI target coq-ext-lib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"coq-ext-lib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -1181,8 +1181,8 @@ jobs:
       name: Checking presence of CI target coq-record-update
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"coq-record-update\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -1233,8 +1233,8 @@ jobs:
       name: Checking presence of CI target coq-shell
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"coq-shell\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -1290,8 +1290,8 @@ jobs:
       name: Checking presence of CI target coqeal
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"coqeal\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -1362,8 +1362,8 @@ jobs:
       name: Checking presence of CI target coqhammer
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"coqhammer\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -1415,8 +1415,8 @@ jobs:
       name: Checking presence of CI target coqprime
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"coqprime\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -1471,8 +1471,8 @@ jobs:
       name: Checking presence of CI target coqtail-math
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"coqtail-math\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -1524,8 +1524,8 @@ jobs:
       name: Checking presence of CI target coquelicot
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"coquelicot\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -1582,8 +1582,8 @@ jobs:
       name: Checking presence of CI target corn
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"corn\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -1643,8 +1643,8 @@ jobs:
       name: Checking presence of CI target deriving
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"deriving\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -1699,8 +1699,8 @@ jobs:
       name: Checking presence of CI target dpdgraph
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"dpdgraph\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -1751,8 +1751,8 @@ jobs:
       name: Checking presence of CI target equations
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"equations\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -1805,8 +1805,8 @@ jobs:
       name: Checking presence of CI target extructures
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"extructures\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -1865,8 +1865,8 @@ jobs:
       name: Checking presence of CI target flocq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"flocq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -1920,8 +1920,8 @@ jobs:
       name: Checking presence of CI target fourcolor
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"fourcolor\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -1987,8 +1987,8 @@ jobs:
       name: Checking presence of CI target gaia
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"gaia\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -2052,8 +2052,8 @@ jobs:
       name: Checking presence of CI target gappalib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"gappalib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -2110,8 +2110,8 @@ jobs:
       name: Checking presence of CI target goedel
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"goedel\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -2175,8 +2175,8 @@ jobs:
       name: Checking presence of CI target graph-theory
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"graph-theory\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -2248,8 +2248,8 @@ jobs:
       name: Checking presence of CI target hierarchy-builder
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"hierarchy-builder\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -2305,8 +2305,8 @@ jobs:
       name: Checking presence of CI target hydra-battles
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"hydra-battles\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -2366,8 +2366,8 @@ jobs:
       name: Checking presence of CI target interval
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"interval\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -2439,8 +2439,8 @@ jobs:
       name: Checking presence of CI target iris
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"iris\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -2496,8 +2496,8 @@ jobs:
       name: Checking presence of CI target math-classes
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"math-classes\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -2558,8 +2558,8 @@ jobs:
       name: Checking presence of CI target mathcomp
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"mathcomp\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -2636,8 +2636,8 @@ jobs:
       name: Checking presence of CI target mathcomp-abel
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"mathcomp-abel\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -2698,8 +2698,8 @@ jobs:
       name: Checking presence of CI target mathcomp-algebra
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"mathcomp-algebra\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -2759,8 +2759,8 @@ jobs:
       name: Checking presence of CI target mathcomp-bigenough
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"mathcomp-bigenough\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -2820,8 +2820,8 @@ jobs:
       name: Checking presence of CI target mathcomp-character
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"mathcomp-character\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -2896,8 +2896,8 @@ jobs:
       name: Checking presence of CI target mathcomp-field
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"mathcomp-field\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -2965,8 +2965,8 @@ jobs:
       name: Checking presence of CI target mathcomp-fingroup
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"mathcomp-fingroup\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -3022,8 +3022,8 @@ jobs:
       name: Checking presence of CI target mathcomp-finmap
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"mathcomp-finmap\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -3084,8 +3084,8 @@ jobs:
       name: Checking presence of CI target mathcomp-real-closed
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"mathcomp-real-closed\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -3163,8 +3163,8 @@ jobs:
       name: Checking presence of CI target mathcomp-solvable
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"mathcomp-solvable\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -3227,8 +3227,8 @@ jobs:
       name: Checking presence of CI target mathcomp-ssreflect
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"mathcomp-ssreflect\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -3281,8 +3281,8 @@ jobs:
       name: Checking presence of CI target mathcomp-tarjan
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"mathcomp-tarjan\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -3344,8 +3344,8 @@ jobs:
       name: Checking presence of CI target mathcomp-word
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"mathcomp-word\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -3413,8 +3413,8 @@ jobs:
       name: Checking presence of CI target metacoq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"metacoq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -3489,8 +3489,8 @@ jobs:
       name: Checking presence of CI target metacoq-erasure
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"metacoq-erasure\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -3559,8 +3559,8 @@ jobs:
       name: Checking presence of CI target metacoq-pcuic
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"metacoq-pcuic\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -3622,8 +3622,8 @@ jobs:
       name: Checking presence of CI target metacoq-safechecker
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"metacoq-safechecker\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -3687,8 +3687,8 @@ jobs:
       name: Checking presence of CI target metacoq-template-coq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"metacoq-template-coq\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -3743,8 +3743,8 @@ jobs:
       name: Checking presence of CI target metalib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"metalib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -3800,8 +3800,8 @@ jobs:
       name: Checking presence of CI target multinomials
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"multinomials\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -3879,8 +3879,8 @@ jobs:
       name: Checking presence of CI target odd-order
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"odd-order\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -3959,8 +3959,8 @@ jobs:
       name: Checking presence of CI target paco
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"paco\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -4011,8 +4011,8 @@ jobs:
       name: Checking presence of CI target paramcoq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"paramcoq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -4065,8 +4065,8 @@ jobs:
       name: Checking presence of CI target parsec
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"parsec\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -4125,8 +4125,8 @@ jobs:
       name: Checking presence of CI target pocklington
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"pocklington\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -4178,8 +4178,8 @@ jobs:
       name: Checking presence of CI target reglang
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"reglang\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -4236,8 +4236,8 @@ jobs:
       name: Checking presence of CI target relation-algebra
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"relation-algebra\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -4296,8 +4296,8 @@ jobs:
       name: Checking presence of CI target semantics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"semantics\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -4348,8 +4348,8 @@ jobs:
       name: Checking presence of CI target serapi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"serapi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -4401,8 +4401,8 @@ jobs:
       name: Checking presence of CI target simple-io
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"simple-io\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -4457,8 +4457,8 @@ jobs:
       name: Checking presence of CI target smpl
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"smpl\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -4509,8 +4509,8 @@ jobs:
       name: Checking presence of CI target stdpp
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"stdpp\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -4561,8 +4561,8 @@ jobs:
       name: Checking presence of CI target tlc
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"tlc\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -4614,8 +4614,8 @@ jobs:
       name: Checking presence of CI target topology
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"topology\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr
@@ -4670,8 +4670,8 @@ jobs:
       name: Checking presence of CI target zorns-lemma
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.12\" --argstr job \"zorns-lemma\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.12" --argstr

--- a/.github/workflows/nix-action-8.13.yml
+++ b/.github/workflows/nix-action-8.13.yml
@@ -42,8 +42,8 @@ jobs:
       name: Checking presence of CI target Cheerios
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"Cheerios\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -98,8 +98,8 @@ jobs:
       name: Checking presence of CI target CoLoR
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"CoLoR\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -152,8 +152,8 @@ jobs:
       name: Checking presence of CI target ITree
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"ITree\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -212,8 +212,8 @@ jobs:
       name: Checking presence of CI target InfSeqExt
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"InfSeqExt\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -264,8 +264,8 @@ jobs:
       name: Checking presence of CI target LibHyps
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"LibHyps\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -319,8 +319,8 @@ jobs:
       name: Checking presence of CI target QuickChick
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"QuickChick\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -383,8 +383,8 @@ jobs:
       name: Checking presence of CI target StructTact
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"StructTact\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -436,8 +436,8 @@ jobs:
       name: Checking presence of CI target VST
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"VST\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -495,8 +495,8 @@ jobs:
       name: Checking presence of CI target Verdi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"Verdi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -559,8 +559,8 @@ jobs:
       name: Checking presence of CI target aac-tactics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"aac-tactics\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -615,8 +615,8 @@ jobs:
       name: Checking presence of CI target addition-chains
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"addition-chains\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -684,8 +684,8 @@ jobs:
       name: Checking presence of CI target autosubst
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"autosubst\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -740,8 +740,8 @@ jobs:
       name: Checking presence of CI target bignums
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"bignums\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -794,8 +794,8 @@ jobs:
       name: Checking presence of CI target category-theory
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"category-theory\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -854,8 +854,8 @@ jobs:
       name: Checking presence of CI target ceres
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"ceres\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -907,8 +907,8 @@ jobs:
       name: Checking presence of CI target compcert
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"compcert\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -962,8 +962,8 @@ jobs:
       name: Checking presence of CI target coq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"coq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: Building/fetching current CI target
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -1011,8 +1011,8 @@ jobs:
       name: Checking presence of CI target coq-bits
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"coq-bits\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -1067,8 +1067,8 @@ jobs:
       name: Checking presence of CI target coq-elpi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"coq-elpi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -1119,8 +1119,8 @@ jobs:
       name: Checking presence of CI target coq-ext-lib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"coq-ext-lib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -1171,8 +1171,8 @@ jobs:
       name: Checking presence of CI target coq-record-update
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"coq-record-update\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -1223,8 +1223,8 @@ jobs:
       name: Checking presence of CI target coq-shell
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"coq-shell\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -1279,8 +1279,8 @@ jobs:
       name: Checking presence of CI target coqeal
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"coqeal\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -1347,8 +1347,8 @@ jobs:
       name: Checking presence of CI target coqhammer
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"coqhammer\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -1400,8 +1400,8 @@ jobs:
       name: Checking presence of CI target coqprime
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"coqprime\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -1456,8 +1456,8 @@ jobs:
       name: Checking presence of CI target coqtail-math
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"coqtail-math\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -1509,8 +1509,8 @@ jobs:
       name: Checking presence of CI target coquelicot
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"coquelicot\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -1567,8 +1567,8 @@ jobs:
       name: Checking presence of CI target corn
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"corn\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -1628,8 +1628,8 @@ jobs:
       name: Checking presence of CI target deriving
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"deriving\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -1684,8 +1684,8 @@ jobs:
       name: Checking presence of CI target dpdgraph
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"dpdgraph\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -1736,8 +1736,8 @@ jobs:
       name: Checking presence of CI target equations
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"equations\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -1790,8 +1790,8 @@ jobs:
       name: Checking presence of CI target extructures
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"extructures\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -1850,8 +1850,8 @@ jobs:
       name: Checking presence of CI target flocq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"flocq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -1905,8 +1905,8 @@ jobs:
       name: Checking presence of CI target fourcolor
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"fourcolor\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -1972,8 +1972,8 @@ jobs:
       name: Checking presence of CI target gaia
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"gaia\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -2039,8 +2039,8 @@ jobs:
       name: Checking presence of CI target gaia-hydras
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"gaia-hydras\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -2104,8 +2104,8 @@ jobs:
       name: Checking presence of CI target gappalib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"gappalib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -2162,8 +2162,8 @@ jobs:
       name: Checking presence of CI target goedel
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"goedel\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -2223,8 +2223,8 @@ jobs:
       name: Checking presence of CI target hierarchy-builder
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"hierarchy-builder\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -2281,8 +2281,8 @@ jobs:
       name: Checking presence of CI target hydra-battles
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"hydra-battles\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -2346,8 +2346,8 @@ jobs:
       name: Checking presence of CI target interval
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"interval\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -2419,8 +2419,8 @@ jobs:
       name: Checking presence of CI target iris
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"iris\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -2475,8 +2475,8 @@ jobs:
       name: Checking presence of CI target itauto
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"itauto\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -2528,8 +2528,8 @@ jobs:
       name: Checking presence of CI target math-classes
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"math-classes\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -2590,8 +2590,8 @@ jobs:
       name: Checking presence of CI target mathcomp
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"mathcomp\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -2668,8 +2668,8 @@ jobs:
       name: Checking presence of CI target mathcomp-algebra
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"mathcomp-algebra\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -2731,8 +2731,8 @@ jobs:
       name: Checking presence of CI target mathcomp-algebra-tactics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"mathcomp-algebra-tactics\" \\\n   --dry-run\
-        \ 2>&1 > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run\
-        \ | grep \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ 2>&1 > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -2801,8 +2801,8 @@ jobs:
       name: Checking presence of CI target mathcomp-apery
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"mathcomp-apery\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -2878,8 +2878,8 @@ jobs:
       name: Checking presence of CI target mathcomp-bigenough
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"mathcomp-bigenough\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -2939,8 +2939,8 @@ jobs:
       name: Checking presence of CI target mathcomp-character
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"mathcomp-character\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -3015,8 +3015,8 @@ jobs:
       name: Checking presence of CI target mathcomp-field
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"mathcomp-field\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -3084,8 +3084,8 @@ jobs:
       name: Checking presence of CI target mathcomp-fingroup
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"mathcomp-fingroup\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -3141,8 +3141,8 @@ jobs:
       name: Checking presence of CI target mathcomp-finmap
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"mathcomp-finmap\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -3203,8 +3203,8 @@ jobs:
       name: Checking presence of CI target mathcomp-real-closed
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"mathcomp-real-closed\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -3282,8 +3282,8 @@ jobs:
       name: Checking presence of CI target mathcomp-solvable
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"mathcomp-solvable\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -3346,8 +3346,8 @@ jobs:
       name: Checking presence of CI target mathcomp-ssreflect
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"mathcomp-ssreflect\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -3400,8 +3400,8 @@ jobs:
       name: Checking presence of CI target mathcomp-tarjan
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"mathcomp-tarjan\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -3463,8 +3463,8 @@ jobs:
       name: Checking presence of CI target mathcomp-word
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"mathcomp-word\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -3530,8 +3530,8 @@ jobs:
       name: Checking presence of CI target mathcomp-zify
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"mathcomp-zify\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -3594,8 +3594,8 @@ jobs:
       name: Checking presence of CI target metalib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"metalib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -3651,8 +3651,8 @@ jobs:
       name: Checking presence of CI target multinomials
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"multinomials\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -3723,8 +3723,8 @@ jobs:
       name: Checking presence of CI target paco
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"paco\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -3775,8 +3775,8 @@ jobs:
       name: Checking presence of CI target paramcoq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"paramcoq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -3829,8 +3829,8 @@ jobs:
       name: Checking presence of CI target parsec
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"parsec\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -3889,8 +3889,8 @@ jobs:
       name: Checking presence of CI target pocklington
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"pocklington\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -3942,8 +3942,8 @@ jobs:
       name: Checking presence of CI target reglang
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"reglang\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -4000,8 +4000,8 @@ jobs:
       name: Checking presence of CI target relation-algebra
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"relation-algebra\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -4060,8 +4060,8 @@ jobs:
       name: Checking presence of CI target semantics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"semantics\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -4112,8 +4112,8 @@ jobs:
       name: Checking presence of CI target serapi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"serapi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -4165,8 +4165,8 @@ jobs:
       name: Checking presence of CI target simple-io
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"simple-io\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -4221,8 +4221,8 @@ jobs:
       name: Checking presence of CI target smpl
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"smpl\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -4274,8 +4274,8 @@ jobs:
       name: Checking presence of CI target smtcoq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"smtcoq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -4330,8 +4330,8 @@ jobs:
       name: Checking presence of CI target stdpp
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"stdpp\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -4382,8 +4382,8 @@ jobs:
       name: Checking presence of CI target tlc
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"tlc\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -4435,8 +4435,8 @@ jobs:
       name: Checking presence of CI target topology
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"topology\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -4492,8 +4492,8 @@ jobs:
       name: Checking presence of CI target trakt
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"trakt\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr
@@ -4548,8 +4548,8 @@ jobs:
       name: Checking presence of CI target zorns-lemma
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.13\" --argstr job \"zorns-lemma\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.13" --argstr

--- a/.github/workflows/nix-action-8.14.yml
+++ b/.github/workflows/nix-action-8.14.yml
@@ -42,8 +42,8 @@ jobs:
       name: Checking presence of CI target Cheerios
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"Cheerios\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -99,8 +99,8 @@ jobs:
       name: Checking presence of CI target CoLoR
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"CoLoR\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -155,8 +155,8 @@ jobs:
       name: Checking presence of CI target HoTT
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"HoTT\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -209,8 +209,8 @@ jobs:
       name: Checking presence of CI target ITree
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"ITree\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -269,8 +269,8 @@ jobs:
       name: Checking presence of CI target InfSeqExt
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"InfSeqExt\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -321,8 +321,8 @@ jobs:
       name: Checking presence of CI target LibHyps
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"LibHyps\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -376,8 +376,8 @@ jobs:
       name: Checking presence of CI target QuickChick
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"QuickChick\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -440,8 +440,8 @@ jobs:
       name: Checking presence of CI target StructTact
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"StructTact\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -493,8 +493,8 @@ jobs:
       name: Checking presence of CI target VST
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"VST\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -552,8 +552,8 @@ jobs:
       name: Checking presence of CI target Verdi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"Verdi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -616,8 +616,8 @@ jobs:
       name: Checking presence of CI target aac-tactics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"aac-tactics\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -672,8 +672,8 @@ jobs:
       name: Checking presence of CI target addition-chains
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"addition-chains\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -741,8 +741,8 @@ jobs:
       name: Checking presence of CI target autosubst
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"autosubst\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -797,8 +797,8 @@ jobs:
       name: Checking presence of CI target bignums
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"bignums\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -851,8 +851,8 @@ jobs:
       name: Checking presence of CI target category-theory
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"category-theory\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -911,8 +911,8 @@ jobs:
       name: Checking presence of CI target ceres
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"ceres\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -964,8 +964,8 @@ jobs:
       name: Checking presence of CI target compcert
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"compcert\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -1019,8 +1019,8 @@ jobs:
       name: Checking presence of CI target coq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"coq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: Building/fetching current CI target
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -1068,8 +1068,8 @@ jobs:
       name: Checking presence of CI target coq-bits
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"coq-bits\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -1124,8 +1124,8 @@ jobs:
       name: Checking presence of CI target coq-elpi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"coq-elpi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -1176,8 +1176,8 @@ jobs:
       name: Checking presence of CI target coq-ext-lib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"coq-ext-lib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -1228,8 +1228,8 @@ jobs:
       name: Checking presence of CI target coq-record-update
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"coq-record-update\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -1280,8 +1280,8 @@ jobs:
       name: Checking presence of CI target coq-shell
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"coq-shell\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -1336,8 +1336,8 @@ jobs:
       name: Checking presence of CI target coqeal
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"coqeal\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -1404,8 +1404,8 @@ jobs:
       name: Checking presence of CI target coqhammer
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"coqhammer\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -1456,8 +1456,8 @@ jobs:
       name: Checking presence of CI target coqide
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"coqide\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -1509,8 +1509,8 @@ jobs:
       name: Checking presence of CI target coqprime
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"coqprime\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -1565,8 +1565,8 @@ jobs:
       name: Checking presence of CI target coqtail-math
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"coqtail-math\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -1618,8 +1618,8 @@ jobs:
       name: Checking presence of CI target coquelicot
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"coquelicot\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -1676,8 +1676,8 @@ jobs:
       name: Checking presence of CI target corn
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"corn\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -1737,8 +1737,8 @@ jobs:
       name: Checking presence of CI target deriving
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"deriving\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -1793,8 +1793,8 @@ jobs:
       name: Checking presence of CI target dpdgraph
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"dpdgraph\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -1845,8 +1845,8 @@ jobs:
       name: Checking presence of CI target equations
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"equations\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -1899,8 +1899,8 @@ jobs:
       name: Checking presence of CI target extructures
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"extructures\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -1959,8 +1959,8 @@ jobs:
       name: Checking presence of CI target flocq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"flocq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -2014,8 +2014,8 @@ jobs:
       name: Checking presence of CI target fourcolor
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"fourcolor\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -2081,8 +2081,8 @@ jobs:
       name: Checking presence of CI target gaia
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"gaia\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -2148,8 +2148,8 @@ jobs:
       name: Checking presence of CI target gaia-hydras
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"gaia-hydras\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -2213,8 +2213,8 @@ jobs:
       name: Checking presence of CI target gappalib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"gappalib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -2271,8 +2271,8 @@ jobs:
       name: Checking presence of CI target goedel
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"goedel\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -2336,8 +2336,8 @@ jobs:
       name: Checking presence of CI target graph-theory
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"graph-theory\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -2409,8 +2409,8 @@ jobs:
       name: Checking presence of CI target hierarchy-builder
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"hierarchy-builder\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -2467,8 +2467,8 @@ jobs:
       name: Checking presence of CI target hydra-battles
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"hydra-battles\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -2532,8 +2532,8 @@ jobs:
       name: Checking presence of CI target interval
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"interval\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -2605,8 +2605,8 @@ jobs:
       name: Checking presence of CI target iris
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"iris\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -2661,8 +2661,8 @@ jobs:
       name: Checking presence of CI target itauto
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"itauto\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -2714,8 +2714,8 @@ jobs:
       name: Checking presence of CI target math-classes
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"math-classes\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -2776,8 +2776,8 @@ jobs:
       name: Checking presence of CI target mathcomp
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"mathcomp\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -2854,8 +2854,8 @@ jobs:
       name: Checking presence of CI target mathcomp-algebra
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"mathcomp-algebra\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -2917,8 +2917,8 @@ jobs:
       name: Checking presence of CI target mathcomp-algebra-tactics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"mathcomp-algebra-tactics\" \\\n   --dry-run\
-        \ 2>&1 > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run\
-        \ | grep \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ 2>&1 > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -2985,8 +2985,8 @@ jobs:
       name: Checking presence of CI target mathcomp-analysis
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"mathcomp-analysis\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -3059,8 +3059,8 @@ jobs:
       name: Checking presence of CI target mathcomp-apery
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"mathcomp-apery\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -3136,8 +3136,8 @@ jobs:
       name: Checking presence of CI target mathcomp-bigenough
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"mathcomp-bigenough\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -3197,8 +3197,8 @@ jobs:
       name: Checking presence of CI target mathcomp-character
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"mathcomp-character\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -3272,8 +3272,8 @@ jobs:
       name: Checking presence of CI target mathcomp-classical
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"mathcomp-classical\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -3340,8 +3340,8 @@ jobs:
       name: Checking presence of CI target mathcomp-field
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"mathcomp-field\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -3409,8 +3409,8 @@ jobs:
       name: Checking presence of CI target mathcomp-fingroup
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"mathcomp-fingroup\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -3466,8 +3466,8 @@ jobs:
       name: Checking presence of CI target mathcomp-finmap
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"mathcomp-finmap\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -3528,8 +3528,8 @@ jobs:
       name: Checking presence of CI target mathcomp-real-closed
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"mathcomp-real-closed\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -3607,8 +3607,8 @@ jobs:
       name: Checking presence of CI target mathcomp-solvable
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"mathcomp-solvable\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -3671,8 +3671,8 @@ jobs:
       name: Checking presence of CI target mathcomp-ssreflect
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"mathcomp-ssreflect\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -3725,8 +3725,8 @@ jobs:
       name: Checking presence of CI target mathcomp-tarjan
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"mathcomp-tarjan\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -3788,8 +3788,8 @@ jobs:
       name: Checking presence of CI target mathcomp-word
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"mathcomp-word\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -3855,8 +3855,8 @@ jobs:
       name: Checking presence of CI target mathcomp-zify
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"mathcomp-zify\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -3924,8 +3924,8 @@ jobs:
       name: Checking presence of CI target metacoq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"metacoq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -4000,8 +4000,8 @@ jobs:
       name: Checking presence of CI target metacoq-erasure
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"metacoq-erasure\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -4070,8 +4070,8 @@ jobs:
       name: Checking presence of CI target metacoq-pcuic
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"metacoq-pcuic\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -4133,8 +4133,8 @@ jobs:
       name: Checking presence of CI target metacoq-safechecker
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"metacoq-safechecker\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -4198,8 +4198,8 @@ jobs:
       name: Checking presence of CI target metacoq-template-coq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"metacoq-template-coq\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -4254,8 +4254,8 @@ jobs:
       name: Checking presence of CI target metalib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"metalib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -4311,8 +4311,8 @@ jobs:
       name: Checking presence of CI target multinomials
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"multinomials\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -4383,8 +4383,8 @@ jobs:
       name: Checking presence of CI target paco
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"paco\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -4435,8 +4435,8 @@ jobs:
       name: Checking presence of CI target paramcoq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"paramcoq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -4489,8 +4489,8 @@ jobs:
       name: Checking presence of CI target parsec
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"parsec\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -4549,8 +4549,8 @@ jobs:
       name: Checking presence of CI target pocklington
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"pocklington\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -4602,8 +4602,8 @@ jobs:
       name: Checking presence of CI target reglang
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"reglang\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -4660,8 +4660,8 @@ jobs:
       name: Checking presence of CI target relation-algebra
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"relation-algebra\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -4720,8 +4720,8 @@ jobs:
       name: Checking presence of CI target semantics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"semantics\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -4772,8 +4772,8 @@ jobs:
       name: Checking presence of CI target serapi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"serapi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -4825,8 +4825,8 @@ jobs:
       name: Checking presence of CI target simple-io
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"simple-io\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -4881,8 +4881,8 @@ jobs:
       name: Checking presence of CI target smpl
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"smpl\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -4933,8 +4933,8 @@ jobs:
       name: Checking presence of CI target stdpp
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"stdpp\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -4985,8 +4985,8 @@ jobs:
       name: Checking presence of CI target tlc
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"tlc\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -5038,8 +5038,8 @@ jobs:
       name: Checking presence of CI target topology
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"topology\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -5095,8 +5095,8 @@ jobs:
       name: Checking presence of CI target trakt
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"trakt\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr
@@ -5151,8 +5151,8 @@ jobs:
       name: Checking presence of CI target zorns-lemma
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.14\" --argstr job \"zorns-lemma\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.14" --argstr

--- a/.github/workflows/nix-action-8.15.yml
+++ b/.github/workflows/nix-action-8.15.yml
@@ -42,8 +42,8 @@ jobs:
       name: Checking presence of CI target Cheerios
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"Cheerios\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -99,8 +99,8 @@ jobs:
       name: Checking presence of CI target CoLoR
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"CoLoR\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -155,8 +155,8 @@ jobs:
       name: Checking presence of CI target HoTT
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"HoTT\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -209,8 +209,8 @@ jobs:
       name: Checking presence of CI target ITree
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"ITree\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -269,8 +269,8 @@ jobs:
       name: Checking presence of CI target InfSeqExt
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"InfSeqExt\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -321,8 +321,8 @@ jobs:
       name: Checking presence of CI target LibHyps
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"LibHyps\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -376,8 +376,8 @@ jobs:
       name: Checking presence of CI target QuickChick
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"QuickChick\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -440,8 +440,8 @@ jobs:
       name: Checking presence of CI target StructTact
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"StructTact\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -493,8 +493,8 @@ jobs:
       name: Checking presence of CI target VST
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"VST\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -552,8 +552,8 @@ jobs:
       name: Checking presence of CI target Verdi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"Verdi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -616,8 +616,8 @@ jobs:
       name: Checking presence of CI target aac-tactics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"aac-tactics\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -672,8 +672,8 @@ jobs:
       name: Checking presence of CI target addition-chains
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"addition-chains\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -741,8 +741,8 @@ jobs:
       name: Checking presence of CI target autosubst
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"autosubst\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -797,8 +797,8 @@ jobs:
       name: Checking presence of CI target bignums
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"bignums\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -851,8 +851,8 @@ jobs:
       name: Checking presence of CI target category-theory
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"category-theory\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -911,8 +911,8 @@ jobs:
       name: Checking presence of CI target ceres
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"ceres\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -964,8 +964,8 @@ jobs:
       name: Checking presence of CI target compcert
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"compcert\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -1019,8 +1019,8 @@ jobs:
       name: Checking presence of CI target coq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"coq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: Building/fetching current CI target
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -1068,8 +1068,8 @@ jobs:
       name: Checking presence of CI target coq-bits
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"coq-bits\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -1124,8 +1124,8 @@ jobs:
       name: Checking presence of CI target coq-elpi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"coq-elpi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -1176,8 +1176,8 @@ jobs:
       name: Checking presence of CI target coq-ext-lib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"coq-ext-lib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -1228,8 +1228,8 @@ jobs:
       name: Checking presence of CI target coq-record-update
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"coq-record-update\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -1280,8 +1280,8 @@ jobs:
       name: Checking presence of CI target coq-shell
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"coq-shell\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -1337,8 +1337,8 @@ jobs:
       name: Checking presence of CI target coqeal
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"coqeal\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -1409,8 +1409,8 @@ jobs:
       name: Checking presence of CI target coqhammer
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"coqhammer\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -1461,8 +1461,8 @@ jobs:
       name: Checking presence of CI target coqide
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"coqide\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -1514,8 +1514,8 @@ jobs:
       name: Checking presence of CI target coqprime
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"coqprime\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -1570,8 +1570,8 @@ jobs:
       name: Checking presence of CI target coqtail-math
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"coqtail-math\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -1623,8 +1623,8 @@ jobs:
       name: Checking presence of CI target coquelicot
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"coquelicot\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -1681,8 +1681,8 @@ jobs:
       name: Checking presence of CI target corn
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"corn\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -1742,8 +1742,8 @@ jobs:
       name: Checking presence of CI target deriving
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"deriving\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -1798,8 +1798,8 @@ jobs:
       name: Checking presence of CI target dpdgraph
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"dpdgraph\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -1850,8 +1850,8 @@ jobs:
       name: Checking presence of CI target equations
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"equations\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -1904,8 +1904,8 @@ jobs:
       name: Checking presence of CI target extructures
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"extructures\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -1964,8 +1964,8 @@ jobs:
       name: Checking presence of CI target flocq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"flocq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -2019,8 +2019,8 @@ jobs:
       name: Checking presence of CI target fourcolor
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"fourcolor\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -2086,8 +2086,8 @@ jobs:
       name: Checking presence of CI target gaia
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"gaia\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -2153,8 +2153,8 @@ jobs:
       name: Checking presence of CI target gaia-hydras
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"gaia-hydras\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -2218,8 +2218,8 @@ jobs:
       name: Checking presence of CI target gappalib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"gappalib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -2276,8 +2276,8 @@ jobs:
       name: Checking presence of CI target goedel
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"goedel\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -2341,8 +2341,8 @@ jobs:
       name: Checking presence of CI target graph-theory
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"graph-theory\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -2414,8 +2414,8 @@ jobs:
       name: Checking presence of CI target hierarchy-builder
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"hierarchy-builder\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -2472,8 +2472,8 @@ jobs:
       name: Checking presence of CI target hydra-battles
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"hydra-battles\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -2537,8 +2537,8 @@ jobs:
       name: Checking presence of CI target interval
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"interval\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -2610,8 +2610,8 @@ jobs:
       name: Checking presence of CI target iris
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"iris\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -2666,8 +2666,8 @@ jobs:
       name: Checking presence of CI target itauto
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"itauto\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -2719,8 +2719,8 @@ jobs:
       name: Checking presence of CI target math-classes
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"math-classes\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -2781,8 +2781,8 @@ jobs:
       name: Checking presence of CI target mathcomp
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"mathcomp\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -2859,8 +2859,8 @@ jobs:
       name: Checking presence of CI target mathcomp-algebra
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"mathcomp-algebra\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -2922,8 +2922,8 @@ jobs:
       name: Checking presence of CI target mathcomp-algebra-tactics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"mathcomp-algebra-tactics\" \\\n   --dry-run\
-        \ 2>&1 > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run\
-        \ | grep \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ 2>&1 > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -2990,8 +2990,8 @@ jobs:
       name: Checking presence of CI target mathcomp-analysis
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"mathcomp-analysis\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -3064,8 +3064,8 @@ jobs:
       name: Checking presence of CI target mathcomp-apery
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"mathcomp-apery\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -3141,8 +3141,8 @@ jobs:
       name: Checking presence of CI target mathcomp-bigenough
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"mathcomp-bigenough\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -3202,8 +3202,8 @@ jobs:
       name: Checking presence of CI target mathcomp-character
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"mathcomp-character\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -3277,8 +3277,8 @@ jobs:
       name: Checking presence of CI target mathcomp-classical
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"mathcomp-classical\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -3345,8 +3345,8 @@ jobs:
       name: Checking presence of CI target mathcomp-field
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"mathcomp-field\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -3414,8 +3414,8 @@ jobs:
       name: Checking presence of CI target mathcomp-fingroup
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"mathcomp-fingroup\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -3471,8 +3471,8 @@ jobs:
       name: Checking presence of CI target mathcomp-finmap
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"mathcomp-finmap\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -3528,8 +3528,8 @@ jobs:
       name: Checking presence of CI target mathcomp-infotheo
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"mathcomp-infotheo\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -3590,8 +3590,8 @@ jobs:
       name: Checking presence of CI target mathcomp-real-closed
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"mathcomp-real-closed\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -3669,8 +3669,8 @@ jobs:
       name: Checking presence of CI target mathcomp-solvable
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"mathcomp-solvable\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -3733,8 +3733,8 @@ jobs:
       name: Checking presence of CI target mathcomp-ssreflect
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"mathcomp-ssreflect\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -3787,8 +3787,8 @@ jobs:
       name: Checking presence of CI target mathcomp-tarjan
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"mathcomp-tarjan\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -3850,8 +3850,8 @@ jobs:
       name: Checking presence of CI target mathcomp-word
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"mathcomp-word\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -3917,8 +3917,8 @@ jobs:
       name: Checking presence of CI target mathcomp-zify
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"mathcomp-zify\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -3986,8 +3986,8 @@ jobs:
       name: Checking presence of CI target metacoq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"metacoq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -4062,8 +4062,8 @@ jobs:
       name: Checking presence of CI target metacoq-erasure
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"metacoq-erasure\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -4132,8 +4132,8 @@ jobs:
       name: Checking presence of CI target metacoq-pcuic
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"metacoq-pcuic\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -4195,8 +4195,8 @@ jobs:
       name: Checking presence of CI target metacoq-safechecker
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"metacoq-safechecker\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -4260,8 +4260,8 @@ jobs:
       name: Checking presence of CI target metacoq-template-coq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"metacoq-template-coq\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -4316,8 +4316,8 @@ jobs:
       name: Checking presence of CI target metalib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"metalib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -4373,8 +4373,8 @@ jobs:
       name: Checking presence of CI target multinomials
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"multinomials\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -4445,8 +4445,8 @@ jobs:
       name: Checking presence of CI target paco
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"paco\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -4497,8 +4497,8 @@ jobs:
       name: Checking presence of CI target paramcoq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"paramcoq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -4551,8 +4551,8 @@ jobs:
       name: Checking presence of CI target parsec
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"parsec\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -4611,8 +4611,8 @@ jobs:
       name: Checking presence of CI target pocklington
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"pocklington\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -4664,8 +4664,8 @@ jobs:
       name: Checking presence of CI target reglang
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"reglang\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -4722,8 +4722,8 @@ jobs:
       name: Checking presence of CI target relation-algebra
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"relation-algebra\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -4782,8 +4782,8 @@ jobs:
       name: Checking presence of CI target semantics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"semantics\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -4834,8 +4834,8 @@ jobs:
       name: Checking presence of CI target serapi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"serapi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -4887,8 +4887,8 @@ jobs:
       name: Checking presence of CI target simple-io
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"simple-io\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -4943,8 +4943,8 @@ jobs:
       name: Checking presence of CI target smpl
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"smpl\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -4995,8 +4995,8 @@ jobs:
       name: Checking presence of CI target stdpp
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"stdpp\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -5047,8 +5047,8 @@ jobs:
       name: Checking presence of CI target tlc
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"tlc\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -5100,8 +5100,8 @@ jobs:
       name: Checking presence of CI target topology
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"topology\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -5157,8 +5157,8 @@ jobs:
       name: Checking presence of CI target trakt
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"trakt\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr
@@ -5213,8 +5213,8 @@ jobs:
       name: Checking presence of CI target zorns-lemma
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.15\" --argstr job \"zorns-lemma\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.15" --argstr

--- a/.github/workflows/nix-action-8.16.yml
+++ b/.github/workflows/nix-action-8.16.yml
@@ -42,8 +42,8 @@ jobs:
       name: Checking presence of CI target Cheerios
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"Cheerios\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -99,8 +99,8 @@ jobs:
       name: Checking presence of CI target CoLoR
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"CoLoR\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -155,8 +155,8 @@ jobs:
       name: Checking presence of CI target HoTT
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"HoTT\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -209,8 +209,8 @@ jobs:
       name: Checking presence of CI target ITree
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"ITree\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -269,8 +269,8 @@ jobs:
       name: Checking presence of CI target InfSeqExt
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"InfSeqExt\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -321,8 +321,8 @@ jobs:
       name: Checking presence of CI target LibHyps
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"LibHyps\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -376,8 +376,8 @@ jobs:
       name: Checking presence of CI target QuickChick
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"QuickChick\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -440,8 +440,8 @@ jobs:
       name: Checking presence of CI target StructTact
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"StructTact\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -493,8 +493,8 @@ jobs:
       name: Checking presence of CI target VST
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"VST\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -552,8 +552,8 @@ jobs:
       name: Checking presence of CI target Verdi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"Verdi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -616,8 +616,8 @@ jobs:
       name: Checking presence of CI target aac-tactics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"aac-tactics\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -672,8 +672,8 @@ jobs:
       name: Checking presence of CI target addition-chains
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"addition-chains\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -741,8 +741,8 @@ jobs:
       name: Checking presence of CI target autosubst
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"autosubst\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -797,8 +797,8 @@ jobs:
       name: Checking presence of CI target bignums
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"bignums\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -851,8 +851,8 @@ jobs:
       name: Checking presence of CI target category-theory
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"category-theory\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -911,8 +911,8 @@ jobs:
       name: Checking presence of CI target ceres
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"ceres\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -964,8 +964,8 @@ jobs:
       name: Checking presence of CI target compcert
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"compcert\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -1019,8 +1019,8 @@ jobs:
       name: Checking presence of CI target coq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"coq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: Building/fetching current CI target
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -1068,8 +1068,8 @@ jobs:
       name: Checking presence of CI target coq-bits
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"coq-bits\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -1124,8 +1124,8 @@ jobs:
       name: Checking presence of CI target coq-elpi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"coq-elpi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -1176,8 +1176,8 @@ jobs:
       name: Checking presence of CI target coq-ext-lib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"coq-ext-lib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -1229,8 +1229,8 @@ jobs:
       name: Checking presence of CI target coq-lsp
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"coq-lsp\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -1285,8 +1285,8 @@ jobs:
       name: Checking presence of CI target coq-record-update
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"coq-record-update\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -1337,8 +1337,8 @@ jobs:
       name: Checking presence of CI target coq-shell
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"coq-shell\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -1394,8 +1394,8 @@ jobs:
       name: Checking presence of CI target coqeal
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"coqeal\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -1466,8 +1466,8 @@ jobs:
       name: Checking presence of CI target coqide
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"coqide\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -1519,8 +1519,8 @@ jobs:
       name: Checking presence of CI target coqprime
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"coqprime\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -1576,8 +1576,8 @@ jobs:
       name: Checking presence of CI target coquelicot
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"coquelicot\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -1634,8 +1634,8 @@ jobs:
       name: Checking presence of CI target corn
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"corn\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -1695,8 +1695,8 @@ jobs:
       name: Checking presence of CI target deriving
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"deriving\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -1751,8 +1751,8 @@ jobs:
       name: Checking presence of CI target dpdgraph
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"dpdgraph\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -1803,8 +1803,8 @@ jobs:
       name: Checking presence of CI target equations
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"equations\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -1857,8 +1857,8 @@ jobs:
       name: Checking presence of CI target extructures
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"extructures\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -1917,8 +1917,8 @@ jobs:
       name: Checking presence of CI target flocq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"flocq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -1972,8 +1972,8 @@ jobs:
       name: Checking presence of CI target fourcolor
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"fourcolor\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -2039,8 +2039,8 @@ jobs:
       name: Checking presence of CI target gaia
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"gaia\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -2106,8 +2106,8 @@ jobs:
       name: Checking presence of CI target gaia-hydras
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"gaia-hydras\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -2171,8 +2171,8 @@ jobs:
       name: Checking presence of CI target gappalib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"gappalib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -2229,8 +2229,8 @@ jobs:
       name: Checking presence of CI target goedel
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"goedel\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -2294,8 +2294,8 @@ jobs:
       name: Checking presence of CI target graph-theory
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"graph-theory\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -2367,8 +2367,8 @@ jobs:
       name: Checking presence of CI target hierarchy-builder
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"hierarchy-builder\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -2425,8 +2425,8 @@ jobs:
       name: Checking presence of CI target hydra-battles
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"hydra-battles\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -2490,8 +2490,8 @@ jobs:
       name: Checking presence of CI target interval
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"interval\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -2563,8 +2563,8 @@ jobs:
       name: Checking presence of CI target iris
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"iris\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -2619,8 +2619,8 @@ jobs:
       name: Checking presence of CI target itauto
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"itauto\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -2672,8 +2672,8 @@ jobs:
       name: Checking presence of CI target math-classes
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"math-classes\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -2734,8 +2734,8 @@ jobs:
       name: Checking presence of CI target mathcomp
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"mathcomp\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -2812,8 +2812,8 @@ jobs:
       name: Checking presence of CI target mathcomp-algebra
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"mathcomp-algebra\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -2875,8 +2875,8 @@ jobs:
       name: Checking presence of CI target mathcomp-algebra-tactics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"mathcomp-algebra-tactics\" \\\n   --dry-run\
-        \ 2>&1 > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run\
-        \ | grep \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ 2>&1 > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -2943,8 +2943,8 @@ jobs:
       name: Checking presence of CI target mathcomp-analysis
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"mathcomp-analysis\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -3017,8 +3017,8 @@ jobs:
       name: Checking presence of CI target mathcomp-apery
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"mathcomp-apery\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -3094,8 +3094,8 @@ jobs:
       name: Checking presence of CI target mathcomp-bigenough
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"mathcomp-bigenough\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -3155,8 +3155,8 @@ jobs:
       name: Checking presence of CI target mathcomp-character
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"mathcomp-character\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -3230,8 +3230,8 @@ jobs:
       name: Checking presence of CI target mathcomp-classical
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"mathcomp-classical\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -3298,8 +3298,8 @@ jobs:
       name: Checking presence of CI target mathcomp-field
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"mathcomp-field\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -3367,8 +3367,8 @@ jobs:
       name: Checking presence of CI target mathcomp-fingroup
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"mathcomp-fingroup\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -3424,8 +3424,8 @@ jobs:
       name: Checking presence of CI target mathcomp-finmap
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"mathcomp-finmap\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -3481,8 +3481,8 @@ jobs:
       name: Checking presence of CI target mathcomp-infotheo
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"mathcomp-infotheo\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -3543,8 +3543,8 @@ jobs:
       name: Checking presence of CI target mathcomp-real-closed
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"mathcomp-real-closed\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -3622,8 +3622,8 @@ jobs:
       name: Checking presence of CI target mathcomp-solvable
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"mathcomp-solvable\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -3686,8 +3686,8 @@ jobs:
       name: Checking presence of CI target mathcomp-ssreflect
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"mathcomp-ssreflect\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -3740,8 +3740,8 @@ jobs:
       name: Checking presence of CI target mathcomp-tarjan
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"mathcomp-tarjan\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -3803,8 +3803,8 @@ jobs:
       name: Checking presence of CI target mathcomp-word
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"mathcomp-word\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -3870,8 +3870,8 @@ jobs:
       name: Checking presence of CI target mathcomp-zify
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"mathcomp-zify\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -3939,8 +3939,8 @@ jobs:
       name: Checking presence of CI target metacoq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"metacoq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -4015,8 +4015,8 @@ jobs:
       name: Checking presence of CI target metacoq-erasure
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"metacoq-erasure\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -4085,8 +4085,8 @@ jobs:
       name: Checking presence of CI target metacoq-pcuic
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"metacoq-pcuic\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -4148,8 +4148,8 @@ jobs:
       name: Checking presence of CI target metacoq-safechecker
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"metacoq-safechecker\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -4213,8 +4213,8 @@ jobs:
       name: Checking presence of CI target metacoq-template-coq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"metacoq-template-coq\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -4269,8 +4269,8 @@ jobs:
       name: Checking presence of CI target metalib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"metalib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -4326,8 +4326,8 @@ jobs:
       name: Checking presence of CI target multinomials
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"multinomials\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -4398,8 +4398,8 @@ jobs:
       name: Checking presence of CI target paco
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"paco\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -4450,8 +4450,8 @@ jobs:
       name: Checking presence of CI target paramcoq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"paramcoq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -4504,8 +4504,8 @@ jobs:
       name: Checking presence of CI target parsec
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"parsec\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -4564,8 +4564,8 @@ jobs:
       name: Checking presence of CI target pocklington
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"pocklington\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -4617,8 +4617,8 @@ jobs:
       name: Checking presence of CI target reglang
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"reglang\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -4675,8 +4675,8 @@ jobs:
       name: Checking presence of CI target relation-algebra
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"relation-algebra\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -4735,8 +4735,8 @@ jobs:
       name: Checking presence of CI target semantics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"semantics\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -4787,8 +4787,8 @@ jobs:
       name: Checking presence of CI target serapi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"serapi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -4840,8 +4840,8 @@ jobs:
       name: Checking presence of CI target simple-io
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"simple-io\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -4896,8 +4896,8 @@ jobs:
       name: Checking presence of CI target stdpp
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"stdpp\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -4948,8 +4948,8 @@ jobs:
       name: Checking presence of CI target tlc
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"tlc\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -5001,8 +5001,8 @@ jobs:
       name: Checking presence of CI target topology
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"topology\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -5058,8 +5058,8 @@ jobs:
       name: Checking presence of CI target trakt
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"trakt\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr
@@ -5114,8 +5114,8 @@ jobs:
       name: Checking presence of CI target zorns-lemma
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.16\" --argstr job \"zorns-lemma\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.16" --argstr

--- a/.github/workflows/nix-action-8.17.yml
+++ b/.github/workflows/nix-action-8.17.yml
@@ -42,8 +42,8 @@ jobs:
       name: Checking presence of CI target Cheerios
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"Cheerios\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -99,8 +99,8 @@ jobs:
       name: Checking presence of CI target CoLoR
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"CoLoR\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -155,8 +155,8 @@ jobs:
       name: Checking presence of CI target HoTT
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"HoTT\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -209,8 +209,8 @@ jobs:
       name: Checking presence of CI target ITree
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"ITree\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -269,8 +269,8 @@ jobs:
       name: Checking presence of CI target InfSeqExt
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"InfSeqExt\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -321,8 +321,8 @@ jobs:
       name: Checking presence of CI target LibHyps
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"LibHyps\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -376,8 +376,8 @@ jobs:
       name: Checking presence of CI target QuickChick
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"QuickChick\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -440,8 +440,8 @@ jobs:
       name: Checking presence of CI target StructTact
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"StructTact\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -495,8 +495,8 @@ jobs:
       name: Checking presence of CI target Verdi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"Verdi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -559,8 +559,8 @@ jobs:
       name: Checking presence of CI target aac-tactics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"aac-tactics\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -615,8 +615,8 @@ jobs:
       name: Checking presence of CI target addition-chains
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"addition-chains\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -684,8 +684,8 @@ jobs:
       name: Checking presence of CI target autosubst
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"autosubst\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -740,8 +740,8 @@ jobs:
       name: Checking presence of CI target bignums
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"bignums\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -794,8 +794,8 @@ jobs:
       name: Checking presence of CI target category-theory
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"category-theory\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -854,8 +854,8 @@ jobs:
       name: Checking presence of CI target ceres
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"ceres\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -907,8 +907,8 @@ jobs:
       name: Checking presence of CI target compcert
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"compcert\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -962,8 +962,8 @@ jobs:
       name: Checking presence of CI target coq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"coq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: Building/fetching current CI target
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -1010,8 +1010,8 @@ jobs:
       name: Checking presence of CI target coq-elpi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"coq-elpi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -1062,8 +1062,8 @@ jobs:
       name: Checking presence of CI target coq-ext-lib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"coq-ext-lib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -1115,8 +1115,8 @@ jobs:
       name: Checking presence of CI target coq-lsp
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"coq-lsp\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -1171,8 +1171,8 @@ jobs:
       name: Checking presence of CI target coq-record-update
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"coq-record-update\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -1223,8 +1223,8 @@ jobs:
       name: Checking presence of CI target coq-shell
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"coq-shell\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -1280,8 +1280,8 @@ jobs:
       name: Checking presence of CI target coqeal
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"coqeal\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -1352,8 +1352,8 @@ jobs:
       name: Checking presence of CI target coqide
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"coqide\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -1405,8 +1405,8 @@ jobs:
       name: Checking presence of CI target coqprime
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"coqprime\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -1462,8 +1462,8 @@ jobs:
       name: Checking presence of CI target coquelicot
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"coquelicot\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -1520,8 +1520,8 @@ jobs:
       name: Checking presence of CI target corn
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"corn\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -1581,8 +1581,8 @@ jobs:
       name: Checking presence of CI target deriving
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"deriving\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -1637,8 +1637,8 @@ jobs:
       name: Checking presence of CI target dpdgraph
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"dpdgraph\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -1689,8 +1689,8 @@ jobs:
       name: Checking presence of CI target equations
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"equations\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -1743,8 +1743,8 @@ jobs:
       name: Checking presence of CI target extructures
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"extructures\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -1803,8 +1803,8 @@ jobs:
       name: Checking presence of CI target flocq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"flocq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -1858,8 +1858,8 @@ jobs:
       name: Checking presence of CI target fourcolor
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"fourcolor\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -1923,8 +1923,8 @@ jobs:
       name: Checking presence of CI target gappalib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"gappalib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -1980,8 +1980,8 @@ jobs:
       name: Checking presence of CI target hierarchy-builder
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"hierarchy-builder\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -2041,8 +2041,8 @@ jobs:
       name: Checking presence of CI target interval
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"interval\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -2114,8 +2114,8 @@ jobs:
       name: Checking presence of CI target iris
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"iris\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -2170,8 +2170,8 @@ jobs:
       name: Checking presence of CI target itauto
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"itauto\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -2223,8 +2223,8 @@ jobs:
       name: Checking presence of CI target math-classes
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"math-classes\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -2285,8 +2285,8 @@ jobs:
       name: Checking presence of CI target mathcomp
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"mathcomp\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -2363,8 +2363,8 @@ jobs:
       name: Checking presence of CI target mathcomp-algebra
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"mathcomp-algebra\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -2426,8 +2426,8 @@ jobs:
       name: Checking presence of CI target mathcomp-algebra-tactics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"mathcomp-algebra-tactics\" \\\n   --dry-run\
-        \ 2>&1 > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run\
-        \ | grep \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ 2>&1 > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -2494,8 +2494,8 @@ jobs:
       name: Checking presence of CI target mathcomp-analysis
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"mathcomp-analysis\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -2563,8 +2563,8 @@ jobs:
       name: Checking presence of CI target mathcomp-bigenough
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"mathcomp-bigenough\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -2624,8 +2624,8 @@ jobs:
       name: Checking presence of CI target mathcomp-character
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"mathcomp-character\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -2699,8 +2699,8 @@ jobs:
       name: Checking presence of CI target mathcomp-classical
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"mathcomp-classical\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -2767,8 +2767,8 @@ jobs:
       name: Checking presence of CI target mathcomp-field
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"mathcomp-field\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -2836,8 +2836,8 @@ jobs:
       name: Checking presence of CI target mathcomp-fingroup
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"mathcomp-fingroup\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -2893,8 +2893,8 @@ jobs:
       name: Checking presence of CI target mathcomp-finmap
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"mathcomp-finmap\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -2950,8 +2950,8 @@ jobs:
       name: Checking presence of CI target mathcomp-infotheo
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"mathcomp-infotheo\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -3012,8 +3012,8 @@ jobs:
       name: Checking presence of CI target mathcomp-real-closed
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"mathcomp-real-closed\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -3091,8 +3091,8 @@ jobs:
       name: Checking presence of CI target mathcomp-solvable
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"mathcomp-solvable\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -3155,8 +3155,8 @@ jobs:
       name: Checking presence of CI target mathcomp-ssreflect
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"mathcomp-ssreflect\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -3209,8 +3209,8 @@ jobs:
       name: Checking presence of CI target mathcomp-tarjan
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"mathcomp-tarjan\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -3272,8 +3272,8 @@ jobs:
       name: Checking presence of CI target mathcomp-word
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"mathcomp-word\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -3339,8 +3339,8 @@ jobs:
       name: Checking presence of CI target mathcomp-zify
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"mathcomp-zify\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -3403,8 +3403,8 @@ jobs:
       name: Checking presence of CI target metalib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"metalib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -3460,8 +3460,8 @@ jobs:
       name: Checking presence of CI target multinomials
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"multinomials\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -3532,8 +3532,8 @@ jobs:
       name: Checking presence of CI target paco
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"paco\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -3584,8 +3584,8 @@ jobs:
       name: Checking presence of CI target paramcoq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"paramcoq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -3638,8 +3638,8 @@ jobs:
       name: Checking presence of CI target parsec
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"parsec\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -3698,8 +3698,8 @@ jobs:
       name: Checking presence of CI target pocklington
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"pocklington\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -3751,8 +3751,8 @@ jobs:
       name: Checking presence of CI target reglang
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"reglang\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -3809,8 +3809,8 @@ jobs:
       name: Checking presence of CI target relation-algebra
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"relation-algebra\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -3869,8 +3869,8 @@ jobs:
       name: Checking presence of CI target semantics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"semantics\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -3921,8 +3921,8 @@ jobs:
       name: Checking presence of CI target serapi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"serapi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -3974,8 +3974,8 @@ jobs:
       name: Checking presence of CI target simple-io
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"simple-io\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -4030,8 +4030,8 @@ jobs:
       name: Checking presence of CI target stdpp
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"stdpp\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -4083,8 +4083,8 @@ jobs:
       name: Checking presence of CI target topology
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"topology\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -4140,8 +4140,8 @@ jobs:
       name: Checking presence of CI target trakt
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"trakt\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr
@@ -4196,8 +4196,8 @@ jobs:
       name: Checking presence of CI target zorns-lemma
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.17\" --argstr job \"zorns-lemma\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.17" --argstr

--- a/.github/workflows/nix-action-8.18.yml
+++ b/.github/workflows/nix-action-8.18.yml
@@ -42,8 +42,8 @@ jobs:
       name: Checking presence of CI target Cheerios
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"Cheerios\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -99,8 +99,8 @@ jobs:
       name: Checking presence of CI target CoLoR
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"CoLoR\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -155,8 +155,8 @@ jobs:
       name: Checking presence of CI target HoTT
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"HoTT\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -207,8 +207,8 @@ jobs:
       name: Checking presence of CI target InfSeqExt
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"InfSeqExt\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -259,8 +259,8 @@ jobs:
       name: Checking presence of CI target LibHyps
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"LibHyps\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -311,8 +311,8 @@ jobs:
       name: Checking presence of CI target StructTact
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"StructTact\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -366,8 +366,8 @@ jobs:
       name: Checking presence of CI target Verdi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"Verdi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -430,8 +430,8 @@ jobs:
       name: Checking presence of CI target aac-tactics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"aac-tactics\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -486,8 +486,8 @@ jobs:
       name: Checking presence of CI target addition-chains
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"addition-chains\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -555,8 +555,8 @@ jobs:
       name: Checking presence of CI target autosubst
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"autosubst\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -611,8 +611,8 @@ jobs:
       name: Checking presence of CI target bignums
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"bignums\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -663,8 +663,8 @@ jobs:
       name: Checking presence of CI target ceres
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"ceres\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -714,8 +714,8 @@ jobs:
       name: Checking presence of CI target coq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"coq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: Building/fetching current CI target
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -762,8 +762,8 @@ jobs:
       name: Checking presence of CI target coq-elpi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"coq-elpi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -814,8 +814,8 @@ jobs:
       name: Checking presence of CI target coq-ext-lib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"coq-ext-lib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -867,8 +867,8 @@ jobs:
       name: Checking presence of CI target coq-lsp
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"coq-lsp\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -923,8 +923,8 @@ jobs:
       name: Checking presence of CI target coq-record-update
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"coq-record-update\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -975,8 +975,8 @@ jobs:
       name: Checking presence of CI target coq-shell
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"coq-shell\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -1032,8 +1032,8 @@ jobs:
       name: Checking presence of CI target coqeal
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"coqeal\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -1104,8 +1104,8 @@ jobs:
       name: Checking presence of CI target coqide
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"coqide\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -1157,8 +1157,8 @@ jobs:
       name: Checking presence of CI target coqprime
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"coqprime\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -1214,8 +1214,8 @@ jobs:
       name: Checking presence of CI target coquelicot
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"coquelicot\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -1271,8 +1271,8 @@ jobs:
       name: Checking presence of CI target deriving
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"deriving\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -1327,8 +1327,8 @@ jobs:
       name: Checking presence of CI target equations
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"equations\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -1381,8 +1381,8 @@ jobs:
       name: Checking presence of CI target extructures
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"extructures\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -1441,8 +1441,8 @@ jobs:
       name: Checking presence of CI target flocq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"flocq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -1496,8 +1496,8 @@ jobs:
       name: Checking presence of CI target fourcolor
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"fourcolor\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -1561,8 +1561,8 @@ jobs:
       name: Checking presence of CI target hierarchy-builder
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"hierarchy-builder\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -1617,8 +1617,8 @@ jobs:
       name: Checking presence of CI target itauto
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"itauto\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -1675,8 +1675,8 @@ jobs:
       name: Checking presence of CI target mathcomp
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"mathcomp\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -1753,8 +1753,8 @@ jobs:
       name: Checking presence of CI target mathcomp-algebra
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"mathcomp-algebra\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -1816,8 +1816,8 @@ jobs:
       name: Checking presence of CI target mathcomp-algebra-tactics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"mathcomp-algebra-tactics\" \\\n   --dry-run\
-        \ 2>&1 > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run\
-        \ | grep \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ 2>&1 > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep\
+        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -1884,8 +1884,8 @@ jobs:
       name: Checking presence of CI target mathcomp-analysis
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"mathcomp-analysis\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -1953,8 +1953,8 @@ jobs:
       name: Checking presence of CI target mathcomp-bigenough
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"mathcomp-bigenough\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -2014,8 +2014,8 @@ jobs:
       name: Checking presence of CI target mathcomp-character
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"mathcomp-character\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -2089,8 +2089,8 @@ jobs:
       name: Checking presence of CI target mathcomp-classical
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"mathcomp-classical\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -2157,8 +2157,8 @@ jobs:
       name: Checking presence of CI target mathcomp-field
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"mathcomp-field\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -2226,8 +2226,8 @@ jobs:
       name: Checking presence of CI target mathcomp-fingroup
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"mathcomp-fingroup\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -2283,8 +2283,8 @@ jobs:
       name: Checking presence of CI target mathcomp-finmap
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"mathcomp-finmap\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -2340,8 +2340,8 @@ jobs:
       name: Checking presence of CI target mathcomp-infotheo
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"mathcomp-infotheo\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -2402,8 +2402,8 @@ jobs:
       name: Checking presence of CI target mathcomp-real-closed
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"mathcomp-real-closed\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -2481,8 +2481,8 @@ jobs:
       name: Checking presence of CI target mathcomp-solvable
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"mathcomp-solvable\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -2545,8 +2545,8 @@ jobs:
       name: Checking presence of CI target mathcomp-ssreflect
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"mathcomp-ssreflect\" \\\n   --dry-run 2>&1\
-        \ > /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ > /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"\
+        built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -2599,8 +2599,8 @@ jobs:
       name: Checking presence of CI target mathcomp-tarjan
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"mathcomp-tarjan\" \\\n   --dry-run 2>&1 >\
-        \ /dev/null)\necho $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep\
-        \ \"built:\" | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        \ /dev/null)\necho $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\"\
+        \ | sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -2662,8 +2662,8 @@ jobs:
       name: Checking presence of CI target mathcomp-word
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"mathcomp-word\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -2729,8 +2729,8 @@ jobs:
       name: Checking presence of CI target mathcomp-zify
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"mathcomp-zify\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -2793,8 +2793,8 @@ jobs:
       name: Checking presence of CI target metalib
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"metalib\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -2850,8 +2850,8 @@ jobs:
       name: Checking presence of CI target multinomials
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"multinomials\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -2922,8 +2922,8 @@ jobs:
       name: Checking presence of CI target paco
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"paco\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -2974,8 +2974,8 @@ jobs:
       name: Checking presence of CI target paramcoq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"paramcoq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -3028,8 +3028,8 @@ jobs:
       name: Checking presence of CI target parsec
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"parsec\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -3088,8 +3088,8 @@ jobs:
       name: Checking presence of CI target pocklington
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"pocklington\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -3141,8 +3141,8 @@ jobs:
       name: Checking presence of CI target reglang
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"reglang\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -3197,8 +3197,8 @@ jobs:
       name: Checking presence of CI target semantics
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"semantics\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -3249,8 +3249,8 @@ jobs:
       name: Checking presence of CI target serapi
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"serapi\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -3302,8 +3302,8 @@ jobs:
       name: Checking presence of CI target simple-io
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"simple-io\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -3359,8 +3359,8 @@ jobs:
       name: Checking presence of CI target topology
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"topology\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -3416,8 +3416,8 @@ jobs:
       name: Checking presence of CI target trakt
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"trakt\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr
@@ -3472,8 +3472,8 @@ jobs:
       name: Checking presence of CI target zorns-lemma
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"8.18\" --argstr job \"zorns-lemma\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "8.18" --argstr

--- a/.github/workflows/nix-action-master.yml
+++ b/.github/workflows/nix-action-master.yml
@@ -40,8 +40,8 @@ jobs:
       name: Checking presence of CI target coq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"master\" --argstr job \"coq\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: Building/fetching current CI target
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "master"
@@ -88,8 +88,8 @@ jobs:
       name: Checking presence of CI target coq-shell
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr\
         \ bundle \"master\" --argstr job \"coq-shell\" \\\n   --dry-run 2>&1 > /dev/null)\n\
-        echo $nb_dry_run\necho name=status::$(echo $nb_dry_run | grep \"built:\" |\
-        \ sed \"s/.*/built/\") >> $GITHUB_OUTPUT\n"
+        echo $nb_dry_run\necho status=$(echo $nb_dry_run | grep \"built:\" | sed \"\
+        s/.*/built/\") >> $GITHUB_OUTPUT\n"
     - if: steps.stepCheck.outputs.status == 'built'
       name: 'Building/fetching previous CI target: coq'
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "master"

--- a/action.nix
+++ b/action.nix
@@ -85,7 +85,7 @@ with builtins; with lib; let
          --argstr bundle "${bundlestr}" --argstr job "${job}" \
          --dry-run 2>&1 > /dev/null)
       echo $nb_dry_run
-      echo name=status::$(echo $nb_dry_run | grep "built:" | sed "s/.*/built/") >> $GITHUB_OUTPUT
+      echo status=$(echo $nb_dry_run | grep "built:" | sed "s/.*/built/") >> $GITHUB_OUTPUT
     '';
   };
 


### PR DESCRIPTION
See commit c4730837f50ae2e1fffed71fe4910a87dbc0a490

It seems we've had the coq nix toolbox silently building nothing maybe during the last three weeks (only realized that when encountering failures on Docker CI in mathcomp whereas Nix CI was all green).

Cc @Zimmi48 @CohenCyril @vbgl 