### PR TITLE
Fine tune events triggering workflows to avoid running useless jobs.

### DIFF
--- a/.github/workflows/nix-action-8.10.yml
+++ b/.github/workflows/nix-action-8.10.yml
@@ -3667,8 +3667,10 @@ name: Nix CI for bundle 8.10
 'on':
   pull_request:
     paths:
-    - .github/workflows/**
+    - .github/workflows/nix-action-8.10.yml
   pull_request_target:
+    paths-ignore:
+    - .github/workflows/nix-action-8.10.yml
     types:
     - opened
     - synchronize

--- a/.github/workflows/nix-action-8.11.yml
+++ b/.github/workflows/nix-action-8.11.yml
@@ -4364,8 +4364,10 @@ name: Nix CI for bundle 8.11
 'on':
   pull_request:
     paths:
-    - .github/workflows/**
+    - .github/workflows/nix-action-8.11.yml
   pull_request_target:
+    paths-ignore:
+    - .github/workflows/nix-action-8.11.yml
     types:
     - opened
     - synchronize

--- a/.github/workflows/nix-action-8.12.yml
+++ b/.github/workflows/nix-action-8.12.yml
@@ -4684,8 +4684,10 @@ name: Nix CI for bundle 8.12
 'on':
   pull_request:
     paths:
-    - .github/workflows/**
+    - .github/workflows/nix-action-8.12.yml
   pull_request_target:
+    paths-ignore:
+    - .github/workflows/nix-action-8.12.yml
     types:
     - opened
     - synchronize

--- a/.github/workflows/nix-action-8.13.yml
+++ b/.github/workflows/nix-action-8.13.yml
@@ -4562,8 +4562,10 @@ name: Nix CI for bundle 8.13
 'on':
   pull_request:
     paths:
-    - .github/workflows/**
+    - .github/workflows/nix-action-8.13.yml
   pull_request_target:
+    paths-ignore:
+    - .github/workflows/nix-action-8.13.yml
     types:
     - opened
     - synchronize

--- a/.github/workflows/nix-action-8.14.yml
+++ b/.github/workflows/nix-action-8.14.yml
@@ -5165,8 +5165,10 @@ name: Nix CI for bundle 8.14
 'on':
   pull_request:
     paths:
-    - .github/workflows/**
+    - .github/workflows/nix-action-8.14.yml
   pull_request_target:
+    paths-ignore:
+    - .github/workflows/nix-action-8.14.yml
     types:
     - opened
     - synchronize

--- a/.github/workflows/nix-action-8.15.yml
+++ b/.github/workflows/nix-action-8.15.yml
@@ -5227,8 +5227,10 @@ name: Nix CI for bundle 8.15
 'on':
   pull_request:
     paths:
-    - .github/workflows/**
+    - .github/workflows/nix-action-8.15.yml
   pull_request_target:
+    paths-ignore:
+    - .github/workflows/nix-action-8.15.yml
     types:
     - opened
     - synchronize

--- a/.github/workflows/nix-action-8.16.yml
+++ b/.github/workflows/nix-action-8.16.yml
@@ -5128,8 +5128,10 @@ name: Nix CI for bundle 8.16
 'on':
   pull_request:
     paths:
-    - .github/workflows/**
+    - .github/workflows/nix-action-8.16.yml
   pull_request_target:
+    paths-ignore:
+    - .github/workflows/nix-action-8.16.yml
     types:
     - opened
     - synchronize

--- a/.github/workflows/nix-action-8.17.yml
+++ b/.github/workflows/nix-action-8.17.yml
@@ -4210,8 +4210,10 @@ name: Nix CI for bundle 8.17
 'on':
   pull_request:
     paths:
-    - .github/workflows/**
+    - .github/workflows/nix-action-8.17.yml
   pull_request_target:
+    paths-ignore:
+    - .github/workflows/nix-action-8.17.yml
     types:
     - opened
     - synchronize

--- a/.github/workflows/nix-action-8.18.yml
+++ b/.github/workflows/nix-action-8.18.yml
@@ -3595,8 +3595,10 @@ name: Nix CI for bundle 8.18
 'on':
   pull_request:
     paths:
-    - .github/workflows/**
+    - .github/workflows/nix-action-8.18.yml
   pull_request_target:
+    paths-ignore:
+    - .github/workflows/nix-action-8.18.yml
     types:
     - opened
     - synchronize

--- a/.github/workflows/nix-action-master.yml
+++ b/.github/workflows/nix-action-master.yml
@@ -102,8 +102,10 @@ name: Nix CI for bundle master
 'on':
   pull_request:
     paths:
-    - .github/workflows/**
+    - .github/workflows/nix-action-master.yml
   pull_request_target:
+    paths-ignore:
+    - .github/workflows/nix-action-master.yml
     types:
     - opened
     - synchronize


### PR DESCRIPTION
This is an attempt at avoiding duplication of workflows when they are modified (only one of the `pull_request` and `pull_request_target` events should match and the `pull_request` event should only match when the workflow itself has been updated).