### PR TITLE
Make cachedMake work with local Nix install and proxy

### DIFF
--- a/.nix/shellHook.sh
+++ b/.nix/shellHook.sh
@@ -219,7 +219,13 @@ fetchCoqOverlay (){
 addNixCommand fetchCoqOverlay
 
 my-nix-build (){
-  env -i PATH=$PATH NIX_PATH=$NIX_PATH nix-build \
+  if [ ${NIX_PATH} ]; then
+    SET_NIX_PATH=NIX_PATH="${NIX_PATH}"
+  fi
+  if [ ${https_proxy} ]; then
+    SET_https_proxy=https_proxy="${https_proxy}"
+  fi
+  env -i PATH=$PATH ${SET_NIX_PATH} ${SET_https_proxy} nix-build \
     --argstr bundle "$selectedBundle" --no-out-link\
     --option narinfo-cache-negative-ttl 0 $*
 }


### PR DESCRIPTION
NIX_PATH is no longer set for local Nix installs: https://github.com/NixOS/nixpkgs/issues/149791 which was yielding the following error:

error: file 'nixpkgs' was not found in the Nix search path (add it using $NIX_PATH or -I)