### PR TITLE
proposal for an executive summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,21 @@
 
 ## General presentation
 
-The Coq Nix Toolbox is a set of helper scripts to ease setting of CI for developments and their reverse dependencies.
-It is based on the [Nix package manager](https://nixos.org/) and its [nixpkgs package repository](https://github.com/NixOS/nixpkgs).
+The [Nix package manager](https://nixos.org/) is a package manager with a strong focus on reproducibility and isolation.
 
-The Coq Nix Toolbox has mainly two purposes:
+The Coq Nix Toolbox is a set of helper scripts to ease setting up a Coq project for use with Nix, for Nix and non-Nix users alike. One of its main features is to generate GitHub Actions configuration files to continuously test a Coq project and its reverse dependencies.
 
-1. It generates [GitHub actions](https://github.com/features/actions) configuration files to trigger a CI for your Coq project and its reverse dependencies.
-   These files are generated in `.github/workflows` and,
-   when pushed to github, they trigger a CI using "github actions".
-   This CI uses the Nix packaging system and a caching mechanism called "cachix".
+Besides Nix, the Coq Nix Toolbox relies on the [nixpkgs package repository](https://github.com/NixOS/nixpkgs) and its large collection of Coq packages.
+
+The Coq Nix Toolbox provide the following features:
+
+1. It can generate [GitHub Actions](https://github.com/features/actions) configuration files to trigger a CI for your Coq project and its reverse dependencies. This CI uses the Nix packaging system and a caching mechanism called [Cachix](https://www.cachix.org/).
 
 2. It offers Nix configurations files so that one can locally obtain a shell with all dependencies preloaded by simply running `nix-shell` in the development root directory.
 
-3. Multiple cases of dependencies (typically different versions of Coq) can be easily handled with "bundles" of (reverse) dependency versions/git refs.
+3. Multiple versions of dependencies (typically different versions of Coq) can be easily handled with "bundles" of (reverse) dependency versions/git refs.
 
-4. One can retrieve locally builds already performed on CI through "cachix".
+4. One can retrieve locally builds already performed on CI thanks to Cachix.
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The Coq Nix Toolbox has mainly two purposes:
 
 3. Multiple cases of dependencies (typically different versions of Coq) can be easily handled with "bundles" of (reverse) dependency versions/git refs.
 
-4 One can retrieve locally builds already performed on CI through "cachix".
+4. One can retrieve locally builds already performed on CI through "cachix".
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Coq Nix Toolbox has mainly two purposes:
    This CI uses the Nix packaging system and a caching mechanism called "cachix".
 
 2. It generates configurations so that dependencies are handled by the shell.
-   The shell in questions is called "nix-shell",
+   The shell in question is called "nix-shell",
    the configurations are called "bundles", and
    local compilation is optimized using caching as provided by "cachix".
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ## General presentation
 
-The Coq Nix Toolbox is a set of Nix helper scripts to automate local builds and CI.
+The Coq Nix Toolbox is a set of helper scripts to ease setting of CI for developments and their reverse dependencies.
+It is based on the [Nix package manager](https://nixos.org/) and its [nixpkgs package repository](https://github.com/NixOS/nixpkgs).
 
 The Coq Nix Toolbox has mainly two purposes:
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ The Coq Nix Toolbox has mainly two purposes:
    when pushed to github, they trigger a CI using "github actions".
    This CI uses the Nix packaging system and a caching mechanism called "cachix".
 
-2. It generates configurations so that dependencies are handled by the shell.
-   The shell in question is called "nix-shell",
-   the configurations are called "bundles", and
-   local compilation is optimized using caching as provided by "cachix".
+2. It offers Nix configurations files so that one can locally obtain a shell with all dependencies preloaded by simply running `nix-shell` in the development root directory.
+
+3. Multiple cases of dependencies (typically different versions of Coq) can be easily handled with "bundles" of (reverse) dependency versions/git refs.
+
+4 One can retrieve locally builds already performed on CI through "cachix".
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It is based on the [Nix package manager](https://nixos.org/) and its [nixpkgs pa
 
 The Coq Nix Toolbox has mainly two purposes:
 
-1. It generates configuration files to trigger a CI for your Coq project.
+1. It generates [GitHub actions](https://github.com/features/actions) configuration files to trigger a CI for your Coq project and its reverse dependencies.
    These files are generated in `.github/workflows` and,
    when pushed to github, they trigger a CI using "github actions".
    This CI uses the Nix packaging system and a caching mechanism called "cachix".

--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # Coq Nix Toolbox
 
-Nix helper scripts to automate local builds and CI
+## General presentation
+
+The Coq Nix Toolbox is a set of Nix helper scripts to automate local builds and CI.
+
+The Coq Nix Toolbox has mainly two purposes:
+
+1. It generates configuration files to trigger a CI for your Coq project.
+   These files are generated in `.github/workflows` and,
+   when pushed to github, they trigger a CI using "github actions".
+   This CI uses the Nix packaging system and a caching mechanism called "cachix".
+
+2. It generates configurations so that dependencies are handled by the shell.
+   The shell in questions is called "nix-shell",
+   the configurations are called "bundles", and
+   local compilation is optimized using caching as provided by "cachix".
 
 ## How to use
 


### PR DESCRIPTION
Hi,

We are relying on the coq-nix-toolbox for a formalization of analysis on top of MathComp.
I do not understand the inner working of the coq-nix-toolbox but I occasionally have
to check the README, and, every time, I have the feeling that the purpose is hard
to grasp by a casual user. I therefore propose to add an executive summary at the top of the
README. It is certainly not accurate but I believe that it could help outisders and
maybe trigger the addition of further explanations about the Nix keywords by people more
knowledgeable than me.

Co-authored-by: @proux01