### PR TITLE
chore(.nix): Don't use url litteral when fetching nixpkgs

### DIFF
--- a/.nix/nixpkgs.nix
+++ b/.nix/nixpkgs.nix
@@ -1,4 +1,4 @@
 fetchTarball {
-    url = https://github.com/NixOS/nixpkgs/archive/14d8890fb9edffcfe0aaa296ffc44547c7be04ab.tar.gz;
+    url = "https://github.com/NixOS/nixpkgs/archive/14d8890fb9edffcfe0aaa296ffc44547c7be04ab.tar.gz";
     sha256 = "0zy5dav7mqlkx9vg1dvd1889nglnc4pws58r5pcwm9mn8qnh2r8r";
   }

--- a/.nix/shellHook.sh
+++ b/.nix/shellHook.sh
@@ -79,7 +79,7 @@ updateNixpkgsUnstable (){
   SHA256=$(nix-prefetch-url --unpack $URL)
   mkdir -p $configDir
   echo "fetchTarball {
-    url = $URL;
+    url = \"$URL\";
     sha256 = \"$SHA256\";
   }" > $configDir/nixpkgs.nix
 }
@@ -91,7 +91,7 @@ updateNixpkgsMaster (){
   SHA256=$(nix-prefetch-url --unpack $URL)
   mkdir -p $configDir
   echo "fetchTarball {
-    url = $URL;
+    url = \"$URL\";
     sha256 = \"$SHA256\";
   }" > $configDir/nixpkgs.nix
 }
@@ -105,7 +105,7 @@ updateNixpkgs (){
        SHA256=$(nix-prefetch-url --unpack $URL)
        mkdir -p $configDir
        echo "fetchTarball {
-         url = $URL;
+         url = \"$URL\";
          sha256 = \"$SHA256\";
        }" > $configDir/nixpkgs.nix
   else


### PR DESCRIPTION
This «feature» is disabled by default when using [lix](https://lix.systems) and a string works the same