### PR TITLE
Fix rocqPackages overrides

### DIFF
--- a/.github/workflows/nix-action-rocq-9.0.yml
+++ b/.github/workflows/nix-action-rocq-9.0.yml
@@ -115,6 +115,64 @@ jobs:
       name: Building/fetching current CI target
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "rocq-9.0"
         --argstr job "rocq-core"
+  rocq-shell:
+    needs:
+    - rocq-core
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine which commit to initially checkout
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"target_commit=${{
+        github.sha }}\" >> $GITHUB_ENV\nelse\n  echo \"target_commit=${{ github.event.pull_request.head.sha
+        }}\" >> $GITHUB_ENV\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ env.target_commit }}
+    - name: Determine which commit to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_commit=${{
+        github.sha }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{ github.event.repository.html_url
+        }} refs/pull/${{ github.event.number }}/merge | cut -f1)\n  mergeable=$(git
+        merge --no-commit --no-ff ${{ github.event.pull_request.base.sha }} > /dev/null
+        2>&1; echo $?; git merge --abort > /dev/null 2>&1 || true)\n  if [ -z \"$merge_commit\"\
+        \ -o \"x$mergeable\" != \"x0\" ]; then\n    echo \"tested_commit=${{ github.event.pull_request.head.sha
+        }}\" >> $GITHUB_ENV\n  else\n    echo \"tested_commit=$merge_commit\" >> $GITHUB_ENV\n\
+        \  fi\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ env.tested_commit }}
+    - name: Cachix install
+      uses: cachix/install-nix-action@v30
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq-community
+      uses: cachix/cachix-action@v15
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        extraPullNames: coq, math-comp
+        name: coq-community
+    - id: stepGetDerivation
+      name: Getting derivation for current job (rocq-shell)
+      run: "NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr bundle
+        \"rocq-9.0\" --argstr job \"rocq-shell\" \\\n   --dry-run 2> err > out ||
+        (touch fail; true)\n"
+    - name: Error reporting
+      run: "echo \"out=\"; cat out\necho \"err=\"; cat err\n"
+    - name: Failure check
+      run: if [ -e fail ]; then exit 1; else exit 0; fi;
+    - id: stepCheck
+      name: Checking presence of CI target for current job
+      run: (echo -n status=; cat out err | grep "built:" | sed "s/.*/built/") >> $GITHUB_OUTPUT
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: rocq-core'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "rocq-9.0"
+        --argstr job "rocq-core"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "rocq-9.0"
+        --argstr job "rocq-shell"
   stdlib:
     needs:
     - rocq-core

--- a/.github/workflows/nix-action-rocq-master.yml
+++ b/.github/workflows/nix-action-rocq-master.yml
@@ -1,67 +1,4 @@
 jobs:
-  bignums:
-    needs:
-    - rocq-core
-    - stdlib
-    runs-on: ubuntu-latest
-    steps:
-    - name: Determine which commit to initially checkout
-      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"target_commit=${{
-        github.sha }}\" >> $GITHUB_ENV\nelse\n  echo \"target_commit=${{ github.event.pull_request.head.sha
-        }}\" >> $GITHUB_ENV\nfi\n"
-    - name: Git checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        ref: ${{ env.target_commit }}
-    - name: Determine which commit to test
-      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_commit=${{
-        github.sha }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{ github.event.repository.html_url
-        }} refs/pull/${{ github.event.number }}/merge | cut -f1)\n  mergeable=$(git
-        merge --no-commit --no-ff ${{ github.event.pull_request.base.sha }} > /dev/null
-        2>&1; echo $?; git merge --abort > /dev/null 2>&1 || true)\n  if [ -z \"$merge_commit\"\
-        \ -o \"x$mergeable\" != \"x0\" ]; then\n    echo \"tested_commit=${{ github.event.pull_request.head.sha
-        }}\" >> $GITHUB_ENV\n  else\n    echo \"tested_commit=$merge_commit\" >> $GITHUB_ENV\n\
-        \  fi\nfi\n"
-    - name: Git checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        ref: ${{ env.tested_commit }}
-    - name: Cachix install
-      uses: cachix/install-nix-action@v30
-      with:
-        nix_path: nixpkgs=channel:nixpkgs-unstable
-    - name: Cachix setup coq-community
-      uses: cachix/cachix-action@v15
-      with:
-        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-        extraPullNames: coq, math-comp
-        name: coq-community
-    - id: stepGetDerivation
-      name: Getting derivation for current job (bignums)
-      run: "NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr bundle
-        \"rocq-master\" --argstr job \"bignums\" \\\n   --dry-run 2> err > out ||
-        (touch fail; true)\n"
-    - name: Error reporting
-      run: "echo \"out=\"; cat out\necho \"err=\"; cat err\n"
-    - name: Failure check
-      run: if [ -e fail ]; then exit 1; else exit 0; fi;
-    - id: stepCheck
-      name: Checking presence of CI target for current job
-      run: (echo -n status=; cat out err | grep "built:" | sed "s/.*/built/") >> $GITHUB_OUTPUT
-    - if: steps.stepCheck.outputs.status == 'built'
-      name: 'Building/fetching previous CI target: rocq-core'
-      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "rocq-master"
-        --argstr job "rocq-core"
-    - if: steps.stepCheck.outputs.status == 'built'
-      name: 'Building/fetching previous CI target: stdlib'
-      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "rocq-master"
-        --argstr job "stdlib"
-    - if: steps.stepCheck.outputs.status == 'built'
-      name: Building/fetching current CI target
-      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "rocq-master"
-        --argstr job "bignums"
   rocq-core:
     needs: []
     runs-on: ubuntu-latest
@@ -115,6 +52,64 @@ jobs:
       name: Building/fetching current CI target
       run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "rocq-master"
         --argstr job "rocq-core"
+  rocq-shell:
+    needs:
+    - rocq-core
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine which commit to initially checkout
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"target_commit=${{
+        github.sha }}\" >> $GITHUB_ENV\nelse\n  echo \"target_commit=${{ github.event.pull_request.head.sha
+        }}\" >> $GITHUB_ENV\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ env.target_commit }}
+    - name: Determine which commit to test
+      run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_commit=${{
+        github.sha }}\" >> $GITHUB_ENV\nelse\n  merge_commit=$(git ls-remote ${{ github.event.repository.html_url
+        }} refs/pull/${{ github.event.number }}/merge | cut -f1)\n  mergeable=$(git
+        merge --no-commit --no-ff ${{ github.event.pull_request.base.sha }} > /dev/null
+        2>&1; echo $?; git merge --abort > /dev/null 2>&1 || true)\n  if [ -z \"$merge_commit\"\
+        \ -o \"x$mergeable\" != \"x0\" ]; then\n    echo \"tested_commit=${{ github.event.pull_request.head.sha
+        }}\" >> $GITHUB_ENV\n  else\n    echo \"tested_commit=$merge_commit\" >> $GITHUB_ENV\n\
+        \  fi\nfi\n"
+    - name: Git checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ env.tested_commit }}
+    - name: Cachix install
+      uses: cachix/install-nix-action@v30
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - name: Cachix setup coq-community
+      uses: cachix/cachix-action@v15
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        extraPullNames: coq, math-comp
+        name: coq-community
+    - id: stepGetDerivation
+      name: Getting derivation for current job (rocq-shell)
+      run: "NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr bundle
+        \"rocq-master\" --argstr job \"rocq-shell\" \\\n   --dry-run 2> err > out
+        || (touch fail; true)\n"
+    - name: Error reporting
+      run: "echo \"out=\"; cat out\necho \"err=\"; cat err\n"
+    - name: Failure check
+      run: if [ -e fail ]; then exit 1; else exit 0; fi;
+    - id: stepCheck
+      name: Checking presence of CI target for current job
+      run: (echo -n status=; cat out err | grep "built:" | sed "s/.*/built/") >> $GITHUB_OUTPUT
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: 'Building/fetching previous CI target: rocq-core'
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "rocq-master"
+        --argstr job "rocq-core"
+    - if: steps.stepCheck.outputs.status == 'built'
+      name: Building/fetching current CI target
+      run: NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link --argstr bundle "rocq-master"
+        --argstr job "rocq-shell"
   stdlib:
     needs:
     - rocq-core

--- a/.nix/fallback-config.nix
+++ b/.nix/fallback-config.nix
@@ -6,7 +6,7 @@ with (import (import ./nixpkgs.nix) {}).lib;
   ## to another supported format.
 
   ## The attribute to build, either from nixpkgs
-  ## of from the overlays located in `.nix/coq-overlays`
+  ## of from the overlays located in `.nix/rocq-overlays` or `.nix/coq-overlays`
   attribute = "coq";
   shell-attribute = "coq-shell";
   src = ../coq-shell;
@@ -34,6 +34,7 @@ with (import (import ./nixpkgs.nix) {}).lib;
     "rocq-master" = {
       isRocq = true;
       rocqPackages.rocq-core.override.version = "master";
+      rocqPackages.stdlib.override.version = "master";
     };
   };
 

--- a/.nix/shellHook.sh
+++ b/.nix/shellHook.sh
@@ -197,7 +197,7 @@ addNixCommand initNixConfig
 createOverlay (){
   Orig=$toolboxDir/template-overlay.nix
   if [[ -n "$1" ]]; then
-       D=$configDir/coq-overlays/$1;
+       D=$configDir/rocq-overlays/$1;
        mkdir -p $D
        cat $Orig > $D/default.nix
        sed -i "s/template/$1/" $D/default.nix
@@ -217,6 +217,18 @@ fetchCoqOverlay (){
   fi
 }
 addNixCommand fetchCoqOverlay
+
+fetchRocqOverlay (){
+  F=$nixpkgs/pkgs/development/rocq-modules/$1/default.nix
+  D=$configDir/rocq-overlays/$1/
+  if [[ -f "$F" ]]
+    then mkdir -p $D; cp $F $D; chmod u+w ${D}default.nix;
+         git add ${D}default.nix
+         echo "You may now amend ${D}default.nix"
+    else echo "usage: fetchRocqOverlay pname"
+  fi
+}
+addNixCommand fetchRocqOverlay
 
 my-nix-build (){
   if [ ${NIX_PATH} ]; then

--- a/.nix/shellHook.sh
+++ b/.nix/shellHook.sh
@@ -23,7 +23,7 @@ printNixEnv () {
   for x in $buildInputs; do printf -- "- "; echo $x | cut -d "-" -f "2-"; done
   echo "propagatedBuildInputs:"
   for x in $propagatedBuildInputs; do printf -- "- "; echo $x | cut -d "-" -f "2-"; done
-  echo "you can pass option --arg override '{coq = \"x.y\"; ...}' to nix-shell to change packages versions"
+  echo "you can pass option --arg override '{rocq-core = \"x.y\"; ...}' to nix-shell to change packages versions"
 }
 addNixCommand printNixEnv
 
@@ -32,22 +32,22 @@ ppNixEnv () {
   for x in $nativeBuildInputs
   do printf -- "- "
      pkgv=$(echo $x | cut -d "-" -f "2-")
-     echo $(echo $pkgv | sed "s/coq[0-9][^\-]*-//")
+     echo $(echo $pkgv | sed "s/rocq-core[0-9][^\-]*-//")
   done
   for x in $propagatedNativeBuildInputs
   do printf -- "- "
      pkgv=$(echo $x | cut -d "-" -f "2-")
-     echo $(echo $pkgv | sed "s/coq[0-9][^\-]*-//")
+     echo $(echo $pkgv | sed "s/rocq-core[0-9][^\-]*-//")
   done
   for x in $buildInputs
   do printf -- "- "
      pkgv=$(echo $x | cut -d "-" -f "2-")
-     echo $(echo $pkgv | sed "s/coq[0-9][^\-]*-//")
+     echo $(echo $pkgv | sed "s/rocq-core[0-9][^\-]*-//")
   done
   for x in $propagatedBuildInputs
   do printf -- "- "
      pkgv=$(echo $x | cut -d "-" -f "2-")
-     echo $(echo $pkgv | sed "s/coq[0-9][^\-]*-//")
+     echo $(echo $pkgv | sed "s/rocq-core[0-9][^\-]*-//")
   done
 }
 addNixCommand ppNixEnv

--- a/README.md
+++ b/README.md
@@ -131,13 +131,13 @@ After one of these three commands, you should leave and re-enter `nix-shell` if 
 One can pass the following arguments to `nix-shell` or `nix-build`:
 - `--arg do-nothing true`: do not even provide Coq, just enough context to execute the above commands.
 - `--argstr bundle t`: select the bundle `t` (one can use the above commands `ppBundles` to know the options and `ppBundleSet` to see their contents)
-- `--arg override '{p1 = v1; ...; pn = vn;}'`: a very condensed inline way to select specific versions of `coq` or any package from `coqPackages` or `ocamlPackages`. E.g. `--arg override '{coq = "8.12"; ...; mathcomp = "1.12.0";}'` to override the current default bundle with the given versions.
+- `--arg override '{p1 = v1; ...; pn = vn;}'`: a very condensed inline way to select specific versions of `rocq-core` or any package from `rocqPackages`, `coqPackages` (using `--arg coq-override`) or `ocamlPackages` (using `--arg ocaml-override`). E.g. `--arg override '{rocq-core = "9.0"; ...; mathcomp = "2.3.0";}'` to override the current default bundle with the given versions.
 - `--arg withEmacs true`: provide a ready to use version of emacs with proofgeneral; for the sake of reproducibility this will **not** use your system emacs nor will it use your user configuration.
 - `--argstr job p`: provide the dependencies for (in case of `nix-shell`) or build (in case of `nix-build`) Coq package `p` instead of the current project, but using the current version of the current project. Combined with `--argstr bundle t` this gives a fully configurable way to test reverse dependencies for various configurations.
 
-## Testing `coqPackages` updates in nixpkgs
+## Testing `rocqPackages` updates in nixpkgs
 
-To test a PR on nixpkgs that modifies the `coqPackages` set, clone this repository, `cd` into it, and run:
+To test a PR on nixpkgs that modifies the `rocqPackages` set, clone this repository, `cd` into it, and run:
 
 ```
 nix-shell --arg do-nothing true --run "updateNixpkgs <pr_owner> <pr_branch>"

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ nix-shell --arg do-nothing true --run "updateNixToolBox & genNixActions"
 
 ## Overlays
 
-You can create directories named after a Coq package and containing `default.nix` files in `.nix/coq-overlays` to override the contents of `coqPackages`.
+You can create directories named after a Coq package and containing `default.nix` files in `.nix/rocq-overlays` or `.nix/coq-overlays` to override the contents of `rocqPackages` or `coqPackages` respectively.
 This can be useful in the following case:
 
 - You depend on a package or a version of a package that is not yet available in nixpkgs.
@@ -63,7 +63,8 @@ This can be useful in the following case:
 - The package that you are building is not yet available in nixpkgs.
 
 
-To amend a package already present in nixpkgs, just run `nix-shell --arg do-nothing true --run "fetchCoqOverlay PACKAGENAME"`.
+To amend a package already present in nixpkgs, just run `nix-shell --arg do-nothing true --run "fetchRocqOverlay PACKAGENAME"`
+or `nix-shell --arg do-nothing true --run "fetchCoqOverlay PACKAGENAME"`.
 To create a package from scratch, run `nix-shell --arg do-nothing true --run "createOverlay PACKAGENAME"` and refer to the nixpkgs documentation available at https://nixos.org/manual/nixpkgs/unstable/#sec-language-coq.
 
 ## Bundles and jobs
@@ -71,7 +72,7 @@ To create a package from scratch, run `nix-shell --arg do-nothing true --run "cr
 Bundles are defined in your `config.nix` file. If you didn't change this part of the auto-generated file, you have a single bundle called "default".
 Bundles are used to create sets of compatible packages. You can override the version of some packages and you can explicitly exclude some incompatible packages.
 
-Jobs represent buildable outputs. You can build any package in `coqPackages` (including any package defined in your `.nix/coq-overlays` directory) with the following command:
+Jobs represent buildable outputs. You can build any package in `rocqPackages` and `coqPackages` (including any package defined in your `.nix/rocq-overlays` and `.nix/coq-overlays` directories) with the following command:
 
 ```
 nix-build --argstr job PACKAGENAME
@@ -112,6 +113,7 @@ When you run `nix-shell`, you get an environment with a few available commands:
 - `ppBundleSet`: print a detailed account of what each bundle contains.
 - `initNixConfig`: create an initial `.nix/config.nix` file.
 - `nixEnv`: displays the list of Nix store locations for all the available packages.
+- `fetchRocqOverlay`: fetch a derivation file from nixpkgs that you may then edit locally to override a package.
 - `fetchCoqOverlay`: fetch a derivation file from nixpkgs that you may then edit locally to override a package.
 - `createOverlay`: create a fresh derivation file from a template, which could then be added to nixpkgs.
 - `cachedMake`: compile the project by reusing build outputs cached (generally thanks to Cachix).

--- a/config-parser-1.0.0/default.nix
+++ b/config-parser-1.0.0/default.nix
@@ -10,6 +10,7 @@ with builtins;
   coq-overlays-dir,
   ocaml-overlays-dir,
   override ? {},
+  coq-override ? {},
   ocaml-override ? {},
   global-override ? {},
   lib,
@@ -33,7 +34,7 @@ in with config; let
         if bundle ? isRocq && config.shell-attribute == "coq-shell" then "rocq-shell"
         else config.shell-attribute;
     in {
-      inherit rocq-coq-packages attribute shell-attribute;
+      inherit attribute shell-attribute;
       # not configurable from config.nix:
       ppath = path-to-attribute ++ [ attribute ];
       shell-ppath = path-to-shell-attribute ++ [ shell-attribute ];
@@ -56,7 +57,8 @@ in with config; let
           job = config-ppath.attribute;
           main-job = true; })
       i
-      (mk-bundles [ config-ppath.rocq-coq-packages ] override)
+      (mk-bundles [ "rocqPackages" ] override)
+      (mk-bundles [ "coqPackages" ] coq-override)
       (mk-bundles [ "ocamlPackages" ] ocaml-override)
       (mk-bundles [ ] global-override)
     ]) config.bundles;

--- a/config-parser-1.0.0/default.nix
+++ b/config-parser-1.0.0/default.nix
@@ -6,6 +6,7 @@ with builtins;
   pkgs ? import ../nixpkgs {}, # some instance of pkgs for libraries
   src ? ./., # the source directory
   overlays-dir,
+  rocq-overlays-dir,
   coq-overlays-dir,
   ocaml-overlays-dir,
   override ? {},
@@ -24,8 +25,7 @@ in with config; let
         if bundle ? isRocq then "rocqPackages" else "coqPackages";
       path-to-attribute = config.path-to-attribute or [ rocq-coq-packages ];
       path-to-shell-attribute =
-        config.path-to-shell-attribute
-        or (config.path-to-attribute or [ "coqPackages" ]);
+        config.path-to-shell-attribute or path-to-attribute;
       attribute =
         if bundle ? isRocq && config.attribute == "coq" then "rocq-core"
         else config.attribute;
@@ -66,7 +66,7 @@ in with config; let
 
   mk-instance = bundleName: bundle: let
     overlays = import ./overlays.nix
-      { inherit lib overlays-dir coq-overlays-dir ocaml-overlays-dir bundle;
+      { inherit lib overlays-dir rocq-overlays-dir coq-overlays-dir ocaml-overlays-dir bundle;
         inherit (config) attribute pname shell-attribute shell-pname src; };
 
     pkgs = import config.nixpkgs { inherit overlays; };

--- a/default.nix
+++ b/default.nix
@@ -14,6 +14,7 @@ in
   nixpkgs-file ? get-path src "nixpkgs.nix",
   shellHook-file ? get-path src "shellHook.sh",
   overlays-dir ? get-path src "overlays",
+  rocq-overlays-dir ? get-path src "rocq-overlays",
   coq-overlays-dir ? get-path src "coq-overlays",
   ocaml-overlays-dir ? get-path src "ocaml-overlays",
   ci-matrix ? false,
@@ -42,7 +43,7 @@ let
     src = src;
     lib = (initial.pkgs.coqPackages.lib or tmp-pkgs.lib)
           // { diag = f: x: f x x; };
-    inherit overlays-dir coq-overlays-dir ocaml-overlays-dir;
+    inherit overlays-dir rocq-overlays-dir coq-overlays-dir ocaml-overlays-dir;
     inherit global-override override ocaml-override;
   };
   my-throw = x: throw "Coq nix toolbox error: ${x}";

--- a/default.nix
+++ b/default.nix
@@ -20,6 +20,7 @@ in
   ci-matrix ? false,
   config ? {},
   override ? {},
+  coq-override ? {},
   ocaml-override ? {},
   global-override ? {},
   withEmacs ? false,
@@ -44,7 +45,7 @@ let
     lib = (initial.pkgs.coqPackages.lib or tmp-pkgs.lib)
           // { diag = f: x: f x x; };
     inherit overlays-dir rocq-overlays-dir coq-overlays-dir ocaml-overlays-dir;
-    inherit global-override override ocaml-override;
+    inherit global-override override coq-override ocaml-override;
   };
   my-throw = x: throw "Coq nix toolbox error: ${x}";
 in

--- a/project-default.nix
+++ b/project-default.nix
@@ -1,6 +1,6 @@
 { config ? {}, withEmacs ? false, print-env ? false, do-nothing ? false,
   update-nixpkgs ? false, ci-matrix ? false,
-  override ? {}, ocaml-override ? {}, global-override ? {},
+  override ? {}, coq-override ? {}, ocaml-override ? {}, global-override ? {},
   bundle ? null, job ? null, inNixShell ? null, src ? ./.,
 }@args:
 let auto = fetchGit {

--- a/template-config.nix
+++ b/template-config.nix
@@ -45,12 +45,17 @@
     ## i.e., Coq <= 8.20 or using Coq shim for Rocq >= 9.0.
     # isRocq = true;
 
+    ## You can override Rocq and other Rocq rocqPackages
+    ## through the following attribute
+    # rocqPackages.rocq-core.override.version = "9.0";
+
     ## You can override Coq and other Coq coqPackages
     ## through the following attribute
     # coqPackages.coq.override.version = "8.11";
 
     ## In some cases, light overrides are not available/enough
     ## in which case you can use either
+    # rocqPackages.<rocq-pkg>.overrideAttrs = o: <overrides>;
     # coqPackages.<coq-pkg>.overrideAttrs = o: <overrides>;
     ## or a "long" overlay to put in `.nix/rocq-overlays` or `.nix/coq-overlays`
     ## you may use `nix-shell --run fetchOverlay <coq-pkg>`
@@ -75,6 +80,7 @@
     ## by default the current package and its shell attributes are main jobs
 
     ## you may mark a package as a CI job as follows
+    #  rocqPackages.<another-pkg>.job = "test";
     #  coqPackages.<another-pkg>.job = "test";
     ## It can then built through
     ## nix-build --argstr bundle "default" --arg job "test";

--- a/template-config.nix
+++ b/template-config.nix
@@ -5,7 +5,8 @@
   ## to another supported format.
 
   ## The attribute to build from the local sources,
-  ## either using nixpkgs data or the overlays located in `.nix/coq-overlays`
+  ## either using nixpkgs data or the overlays located in `.nix/rocq-overlays`
+  ## and `.nix/coq-overlays`
   ## Will determine the default main-job of the bundles defined below
   attribute = "template";
 
@@ -22,7 +23,8 @@
   ## These dependencies will systematically be added to the currently
   ## known dependencies, if any more than Coq.
   ## /!\ Remove this field as soon as the package is available on nixpkgs.
-  ## /!\ Manual overlays in `.nix/coq-overlays` should be preferred then.
+  ## /!\ Manual overlays in `.nix/rocq-overlays` or `.nix/coq-overlays`
+  ##     should be preferred then.
   # buildInputs = [ ];
 
   ## Indicate the relative location of your _CoqProject
@@ -50,7 +52,7 @@
     ## In some cases, light overrides are not available/enough
     ## in which case you can use either
     # coqPackages.<coq-pkg>.overrideAttrs = o: <overrides>;
-    ## or a "long" overlay to put in `.nix/coq-overlays
+    ## or a "long" overlay to put in `.nix/rocq-overlays` or `.nix/coq-overlays`
     ## you may use `nix-shell --run fetchOverlay <coq-pkg>`
     ## to automatically retrieve the one from nixpkgs
     ## if it exists and is correctly named/located


### PR DESCRIPTION
`rocqPackages` overrides were accidentally ignored in non pure Rocq bundles (i.e. `isRocq` not true).
Also add `.nix/rocq-overlays` directory handling and `coq-override` argument.