### PR TITLE
Add support for structuredAttrs being enabled in nixpkgs

### DIFF
--- a/.nix/nixpkgs.nix
+++ b/.nix/nixpkgs.nix
@@ -1,4 +1,4 @@
 fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/b5aa0fbd538984f6e3d201be0005b4463d8b09f8.tar.gz";
-    sha256 = "1r0ixj83k41mmkl6xzdcgxgq2l0vkdw10ld234f8jlljyi9w5xd0";
+    url = "https://github.com/NixOS/nixpkgs/archive/9195f26f08bfe957b4c9462b8e44b83ca18eb88e.tar.gz";
+    sha256 = "1z51kam9w090zsw7icivzy8ab508iq3wz94wjjfpwqm71yc4axj3";
   }

--- a/default.nix
+++ b/default.nix
@@ -93,7 +93,7 @@ with initial.lib; let
 
   mkDeriv = shell:
   if !inNixShell then shell
-  else with selected-instance; shell.overrideAttrs (old: {
+  else with selected-instance; shell.overrideAttrs (old: removeAttrs ({
     inherit (setup.config) nixpkgs coqproject;
     inherit jsonBundle jsonBundles jsonSetupConfig jsonCIbyBundle jsonBundleSet
             jsonCIbyJob shellHook toolboxDir selectedBundle
@@ -102,8 +102,6 @@ with initial.lib; let
     bundles = attrNames setup.bundles;
 
     passthru = (old.passthru or {}) // {inherit action pkgs;};
-
-    COQBIN = optionalString (!do-nothing) "";
 
     coq_version = optionalString (!do-nothing)
        pkgs.coqPackages.coq.coq-version;
@@ -119,10 +117,14 @@ with initial.lib; let
     propagatedBuildInputs = optionals (!do-nothing)
       (old.propagatedBuildInputs or []);
   }
+  // optionalAttrs (!do-nothing) {
+    env = removeAttrs (old.env or { }) [ "COQBIN" ];
+  }
   // optionalAttrs withEmacs {
       inherit emacsInit;
       emacsBin = "${emacs}" + "/bin/emacs";
-  });
+  })
+    (optionals (!do-nothing) [ "COQBIN" ]) );
 
   nix-ci = job: map mkDeriv (if allBundles
     then flatten (mapAttrsToList (_: i: i.ci.subpkgs job) instances)


### PR DESCRIPTION
With `structuredAttrs` enabled, environment variables should live inside the `env` attrset. In the case of this project, this affects COQBIN, as per https://github.com/NixOS/nixpkgs/pull/492142 , which moves it into env.

Setting `COQBIN = "";` in `default.nix` while `env.COQBIN` exists causes an evaluation error:

Error: The `env` attribute set cannot contain any attributes passed to derivation.

To fix this, remove the attr instead if it exists, in either place.

I'm not familiar with this project other than being referred to it via https://github.com/NixOS/nixpkgs/pull/492142#issuecomment-4199721664 , so any pointers are welcome.

Tested `nix-shell --arg do-nothing false --run "genNixActions"` on
* coq-nix-toolbox master + pinned nixpkgs
* coq-nix-toolbox at this PR + pinned nixpkgs
* coq-nix-toolbox at this PR + nixpkgs with https://github.com/NixOS/nixpkgs/pull/492142 (which has been rebased on top of the pinned nixpkgs for easier testing)

and I observe no change in the generated `nix-action.*` files while the eval error is gone.